### PR TITLE
fix: typos, misspellings, and dead code (#253)

### DIFF
--- a/src/reqstool/command.py
+++ b/src/reqstool/command.py
@@ -93,13 +93,14 @@ class Command:
         )
         return argument_parser
 
-    def _add_subparsers_source(self, parser):
+    def _add_subparsers_source(self, parser, include_report_options=True):
         # Subparser for local report
         local_report_parser = parser.add_parser("local", help="local source")
         local_report_parser.add_argument("-p", "--path", help="path description", required=True)
         self._add_argument_output(local_report_parser)
-        self._add_group_by(local_report_parser)
-        self._add_sort_by(local_report_parser)
+        if include_report_options:
+            self._add_group_by(local_report_parser)
+            self._add_sort_by(local_report_parser)
 
         # Subparser for git report
         git_report_parser = parser.add_parser("git", help="git source")
@@ -108,8 +109,9 @@ class Command:
         git_report_parser.add_argument("-b", "--branch", help="branch description")
         git_report_parser.add_argument("-t", "--env_token", help="env_token description")
         self._add_argument_output(git_report_parser)
-        self._add_group_by(git_report_parser)
-        self._add_sort_by(git_report_parser)
+        if include_report_options:
+            self._add_group_by(git_report_parser)
+            self._add_sort_by(git_report_parser)
 
         # Subparser for maven report
         maven_report_parser = parser.add_parser("maven", help="maven source")
@@ -120,8 +122,9 @@ class Command:
         maven_report_parser.add_argument("--version", help="version description", required=True)
         maven_report_parser.add_argument("--classifier", help="classifier description")
         self._add_argument_output(maven_report_parser)
-        self._add_group_by(maven_report_parser)
-        self._add_sort_by(maven_report_parser)
+        if include_report_options:
+            self._add_group_by(maven_report_parser)
+            self._add_sort_by(maven_report_parser)
 
         # Subparser for pypi report
         pypi_report_parser = parser.add_parser("pypi", help="pypi source")
@@ -130,8 +133,9 @@ class Command:
         pypi_report_parser.add_argument("--package", help="package", required=True)
         pypi_report_parser.add_argument("--version", help="version description", required=True)
         self._add_argument_output(pypi_report_parser)
-        self._add_group_by(pypi_report_parser)
-        self._add_sort_by(pypi_report_parser)
+        if include_report_options:
+            self._add_group_by(pypi_report_parser)
+            self._add_sort_by(pypi_report_parser)
 
     def _add_argument_version(self, argument_parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         ver = Utils.get_version()
@@ -186,7 +190,7 @@ class Command:
         )
 
         generate_json_source_subparsers = generate_json_parser.add_subparsers(dest="source", required=True)
-        self._add_subparsers_source(generate_json_source_subparsers)
+        self._add_subparsers_source(generate_json_source_subparsers, include_report_options=False)
 
         # command: status
         status_parser = subparsers.add_parser("status", help="Status on implementations and tests of requirements")

--- a/src/reqstool/commands/status/status.py
+++ b/src/reqstool/commands/status/status.py
@@ -112,7 +112,7 @@ def _status_table(stats_container: StatisticsContainer) -> str:
     col_align = ["center"] * len(headers) if table_data else []
     table = tabulate(tablefmt="fancy_grid", tabular_data=table_data, headers=headers, colalign=col_align)
     table_with_title = f"{title}\n{table}\n"
-    statisics = _summarize_statisics(
+    statistics = _summarize_statistics(
         nr_of_total_reqs=stats_container._total_statistics.nr_of_total_requirements,
         nr_of_completed_reqs=stats_container._total_statistics.nr_of_completed_requirements,
         implemented=stats_container._total_statistics.nr_of_reqs_with_implementation,
@@ -146,12 +146,12 @@ def _status_table(stats_container: StatisticsContainer) -> str:
 
     legend_table_data = tabulate(tablefmt="fancy_grid", tabular_data=legend)
 
-    status = table_with_title + legend_table_data + statisics
+    status = table_with_title + legend_table_data + statistics
 
     return status
 
 
-def _summarize_statisics(
+def _summarize_statistics(
     nr_of_total_reqs: int,
     nr_of_completed_reqs: int,
     implemented: int,
@@ -249,7 +249,7 @@ def _summarize_statisics(
         "SVCs missing MVRs",
     ]
 
-    svc_table = svc_table = tabulate(
+    svc_table = tabulate(
         tablefmt="fancy_grid",
         tabular_data=table_svc_data,
         headers=svc_headers,

--- a/src/reqstool/model_generators/combined_indexed_dataset_generator.py
+++ b/src/reqstool/model_generators/combined_indexed_dataset_generator.py
@@ -365,7 +365,7 @@ class CombinedIndexedDatasetGenerator:
             # check filters against accessible requirements, log errors if requirements are not found
             # requirements that will log a warning will not be processed.
             self.__check_defined_requirements_in_filter(
-                filter=req_filter, accessable_urns=accessible_requirements_per_filter_urn
+                filter=req_filter, accessible_urns=accessible_requirements_per_filter_urn
             )
 
             filtered_out_reqs_per_filter_urn = self.__get_filtered_out_requirements_for_filter_urn(
@@ -502,7 +502,7 @@ class CombinedIndexedDatasetGenerator:
                 # check filters against accessible requirements, log errors if requirements are not found
                 # svcs that will log a warning will not be processed.
                 self.__check_defined_requirements_in_filter(
-                    filter=svc_filter, accessable_urns=accessible_svcs_per_filter_urn
+                    filter=svc_filter, accessible_urns=accessible_svcs_per_filter_urn
                 )
 
                 filtered_out_svcs_per_filter_urn = self.__get_filtered_out_svcs_for_filter_urn(
@@ -640,12 +640,12 @@ class CombinedIndexedDatasetGenerator:
         for svc_urn_id in mvrdata.svc_ids:
             self._mvrs_from_svc[svc_urn_id].remove(mvr_urn_id)
 
-    def __check_defined_requirements_in_filter(self, filter: IDFilters, accessable_urns: Set[UrnId]):
+    def __check_defined_requirements_in_filter(self, filter: IDFilters, accessible_urns: Set[UrnId]):
         if filter.urn_ids_imports:
             for urn_id in filter.urn_ids_imports:
-                if urn_id not in accessable_urns:
-                    logging.warning(f"Cannot import: {urn_id} does not exist or is not accessable")
+                if urn_id not in accessible_urns:
+                    logging.warning(f"Cannot import: {urn_id} does not exist or is not accessible")
         elif filter.urn_ids_excludes:
             for urn_id in filter.urn_ids_excludes:
-                if urn_id not in accessable_urns:
-                    logging.warning(f"Cannot exclude: {urn_id} does not exist or is not accessable")
+                if urn_id not in accessible_urns:
+                    logging.warning(f"Cannot exclude: {urn_id} does not exist or is not accessible")


### PR DESCRIPTION
## Summary

Closes #253. Cosmetic-only fixes identified in the senior dev review (#222):

- **`status.py`**: rename `statisics` → `statistics`, `_summarize_statisics` → `_summarize_statistics`, remove duplicate assignment `svc_table = svc_table`
- **`combined_indexed_dataset_generator.py`**: rename parameter `accessable_urns` → `accessible_urns` (definition + 2 call sites), fix log strings `"is not accessable"` → `"is not accessible"`
- **`command.py`**: remove `--group-by` / `--sort-by` options from the `generate-json` subcommand (they only apply to report generation)

## Test plan

- [x] All 108 existing tests pass (`hatch run dev:pytest tests/`)
- [x] No logic changes — purely identifier renames and dead option removal