### PR TITLE
fix: replace is/is not identity comparisons with ==/!= (#248)

### DIFF
--- a/src/reqstool/commands/status/statistics_container.py
+++ b/src/reqstool/commands/status/statistics_container.py
@@ -64,10 +64,10 @@ class TotalStatisticsItem:
         self.nr_of_reqs_with_implementation += combined_req_test_item.nr_of_implementations
 
         # Some requirements could be completed without any implementation
-        if completed and combined_req_test_item.implementation is IMPLEMENTATION.NOT_APPLICABLE:
+        if completed and combined_req_test_item.implementation == IMPLEMENTATION.NOT_APPLICABLE:
             self.nr_of_completed_reqs_no_implementation += 1
 
-        if combined_req_test_item.implementation is IMPLEMENTATION.NOT_APPLICABLE:
+        if combined_req_test_item.implementation == IMPLEMENTATION.NOT_APPLICABLE:
             self.nr_of_total_reqs_no_implementation += 1
 
         if completed:

--- a/src/reqstool/commands/status/statistics_generator.py
+++ b/src/reqstool/commands/status/statistics_generator.py
@@ -128,12 +128,12 @@ class StatisticsGenerator:
         implementation_ok = False
         if (
             nr_of_implementations > 0
-            and implementation is IMPLEMENTATION.IN_CODE
+            and implementation == IMPLEMENTATION.IN_CODE
             or nr_of_implementations == 0
-            and implementation is IMPLEMENTATION.NOT_APPLICABLE
+            and implementation == IMPLEMENTATION.NOT_APPLICABLE
         ):
             implementation_ok = True
-        elif nr_of_implementations > 0 and implementation is IMPLEMENTATION.NOT_APPLICABLE:
+        elif nr_of_implementations > 0 and implementation == IMPLEMENTATION.NOT_APPLICABLE:
             # Throw error if there are implementations of a requirement that does not expect it
             raise TypeError(f"Requirement {urn_id} should not have an implementation")
 

--- a/src/reqstool/commands/status/status.py
+++ b/src/reqstool/commands/status/status.py
@@ -43,7 +43,7 @@ def _build_table(
     row.append(f"{req_id_color}{req_id}{Style.RESET_ALL}")
 
     # Perform check for implementations
-    if implementation is IMPLEMENTATION.NOT_APPLICABLE:
+    if implementation == IMPLEMENTATION.NOT_APPLICABLE:
         row.extend(["N/A"])
     else:
         row.extend(

--- a/src/reqstool/common/validators/semantic_validator.py
+++ b/src/reqstool/common/validators/semantic_validator.py
@@ -125,7 +125,7 @@ class SemanticValidator:
         # get urn and model
         for model, model_data in combined_raw_dataset.raw_datasets.items():
             # Continue if model is not inital_urn
-            if model is not combined_raw_dataset.initial_model_urn:
+            if model != combined_raw_dataset.initial_model_urn:
                 continue
             if model_data.svcs_data is not None:
                 for svc_urn_id, svc_data in model_data.svcs_data.cases.items():
@@ -153,7 +153,7 @@ class SemanticValidator:
         for model, model_data in combined_raw_dataset.raw_datasets.items():
             # Continue if model is not inital_urn
             if (
-                model is not combined_raw_dataset.initial_model_urn
+                model != combined_raw_dataset.initial_model_urn
                 or not model_data.annotations_data
                 or not model_data.annotations_data.implementations
             ):
@@ -197,7 +197,7 @@ class SemanticValidator:
         errors: List[ValidationError] = []
         for model, model_data in combined_raw_dataset.raw_datasets.items():
             # Continue if model is not inital_urn
-            if model is not combined_raw_dataset.initial_model_urn or not model_data.mvrs_data:
+            if model != combined_raw_dataset.initial_model_urn or not model_data.mvrs_data:
                 continue
             for mvr_data in model_data.mvrs_data.results.values():
                 for svc_id in mvr_data.svc_ids:

--- a/src/reqstool/model_generators/combined_indexed_dataset_generator.py
+++ b/src/reqstool/model_generators/combined_indexed_dataset_generator.py
@@ -104,19 +104,19 @@ class CombinedIndexedDatasetGenerator:
         # if initial urn is not a system then do nothing
         self.__initial_urn_is_variant_ms = self.initial_urn_is_ms = (
             self._crd.raw_datasets[self._crd.initial_model_urn].requirements_data.metadata.variant
-            is VARIANTS.MICROSERVICE
+            == VARIANTS.MICROSERVICE
         )
 
         self.__initial_urn_accessible_urns_non_ms: set[str] = {self._crd.initial_model_urn} | {
             node
             for node in self._accessible_nodes_dict[self._crd.initial_model_urn]
-            if self._crd.raw_datasets[node].requirements_data.metadata.variant is not VARIANTS.MICROSERVICE
+            if self._crd.raw_datasets[node].requirements_data.metadata.variant != VARIANTS.MICROSERVICE
         }
 
         self.__initial_urn_accessible_urns_ms: set[str] = {
             node
             for node in self._accessible_nodes_dict[self._crd.initial_model_urn]
-            if self._crd.raw_datasets[node].requirements_data.metadata.variant is VARIANTS.MICROSERVICE
+            if self._crd.raw_datasets[node].requirements_data.metadata.variant == VARIANTS.MICROSERVICE
         }
 
         self.__process_reqs()
@@ -130,12 +130,12 @@ class CombinedIndexedDatasetGenerator:
             self.__process_filters()
 
     def __is_urn_ms(self, urn: str) -> bool:
-        return self._crd.raw_datasets[urn].requirements_data.metadata.variant is VARIANTS.MICROSERVICE
+        return self._crd.raw_datasets[urn].requirements_data.metadata.variant == VARIANTS.MICROSERVICE
 
     def __process_reqs(self):
         for urn, rds in self._crd.raw_datasets.items():
             # if requirements defined in then only add if ms is initial urn
-            if self.__is_urn_ms(urn) and self._crd.initial_model_urn is not urn:
+            if self.__is_urn_ms(urn) and self._crd.initial_model_urn != urn:
                 continue
 
             self._reqs_from_urn[urn] = []
@@ -154,7 +154,7 @@ class CombinedIndexedDatasetGenerator:
                     assert svcdata.id not in self._svcs
 
                     # if urn is ms and urn is initial urn - remove svc references to reqs from not visited urns
-                    if self.__is_urn_ms(urn) and self._crd.initial_model_urn is not urn:
+                    if self.__is_urn_ms(urn) and self._crd.initial_model_urn != urn:
                         remove_req_ids_from_svcdata: Set[UrnId] = set()
                         for req_urn_id in svcdata.requirement_ids:
                             if req_urn_id.urn not in self.__initial_urn_accessible_urns_non_ms:
@@ -191,7 +191,7 @@ class CombinedIndexedDatasetGenerator:
                     assert mvrdata.id not in self._mvrs
 
                     # if urn is ms and urn is initial urn - remove mvr references to svc from not visited urns
-                    if self.__is_urn_ms(urn) and self._crd.initial_model_urn is not urn:
+                    if self.__is_urn_ms(urn) and self._crd.initial_model_urn != urn:
                         remove_svc_ids_from_mvrdata: Set[UrnId] = set()
                         for svc_urn_id in mvrdata.svc_ids:
                             if svc_urn_id.urn not in self.__initial_urn_accessible_urns_non_ms:

--- a/src/reqstool/model_generators/combined_raw_datasets_generator.py
+++ b/src/reqstool/model_generators/combined_raw_datasets_generator.py
@@ -109,14 +109,14 @@ class CombinedRawDatasetsGenerator:
             raw_datasets[current_urn] = current_imported_model
 
             assert (
-                current_imported_model.requirements_data.metadata.variant is VARIANTS.SYSTEM
-                or current_imported_model.requirements_data.metadata.variant is VARIANTS.EXTERNAL
+                current_imported_model.requirements_data.metadata.variant == VARIANTS.SYSTEM
+                or current_imported_model.requirements_data.metadata.variant == VARIANTS.EXTERNAL
             )
 
             # if current source type is system or external import systems recursively
             if (
-                current_imported_model.requirements_data.metadata.variant is VARIANTS.SYSTEM
-                or current_imported_model.requirements_data.metadata.variant is VARIANTS.EXTERNAL
+                current_imported_model.requirements_data.metadata.variant == VARIANTS.SYSTEM
+                or current_imported_model.requirements_data.metadata.variant == VARIANTS.EXTERNAL
             ):
                 imported_systems = self.__import_systems(
                     raw_datasets=raw_datasets, parent_rd=current_imported_model.requirements_data


### PR DESCRIPTION
## Summary

- Replace `is not` with `!=` for string/UrnId dict-key comparisons in `combined_indexed_dataset_generator.py` and `semantic_validator.py` — these were genuine bugs where object identity was used instead of value equality, silently skipping or including wrong items
- Replace `is` with `==` for enum member comparisons in `combined_indexed_dataset_generator.py`, `combined_raw_datasets_generator.py`, `statistics_generator.py`, `statistics_container.py`, and `status.py` — style/PEP 8 fixes
- `requirements.py` line 37 (`self.__class__ is other.__class__`) left unchanged — correct idiom in `__eq__`

Closes #248

## Test plan

- [x] `hatch run dev:pytest tests/` — 108 passed, 2 deselected