### PR TITLE
fix(urn_id): return UrnId instance from assure_urn_id instead of str (#251)

### DIFF
--- a/src/reqstool/commands/generate_json/generate_json.py
+++ b/src/reqstool/commands/generate_json/generate_json.py
@@ -22,7 +22,7 @@ from reqstool.models.test_data import TEST_RUN_STATUS
 
 class UrnIdHandler(jsonpickle.handlers.BaseHandler):
     def flatten(self, obj, data) -> str:
-        return UrnId.assure_urn_id(obj.urn, obj.id)
+        return str(UrnId.assure_urn_id(obj.urn, obj.id))
 
 
 class RevisionHandler(jsonpickle.handlers.BaseHandler):

--- a/src/reqstool/common/dataclasses/urn_id.py
+++ b/src/reqstool/common/dataclasses/urn_id.py
@@ -17,14 +17,11 @@ class UrnId:
         return UrnId(urn=urn, id=id_)
 
     @staticmethod
-    def assure_urn_id(urn: str, id: str) -> str:
-        urn_id = None
+    def assure_urn_id(urn: str, id: str) -> "UrnId":
         if URN_ID_SEPARATOR in id:
-            urn_id = id
+            return UrnId.instance(id)
         else:
-            urn_id = f"{urn}:{id}"
-
-        return urn_id
+            return UrnId(urn=urn, id=id)
 
     def __lt__(self, other: "UrnId"):
         if not isinstance(other, UrnId):

--- a/src/reqstool/expression_languages/generic_el.py
+++ b/src/reqstool/expression_languages/generic_el.py
@@ -78,12 +78,12 @@ class GenericELTransformer(
 
     @v_args(inline=True)
     def comp_id_regex_equals(self, regexp: re.Pattern) -> bool:
-        return bool(regexp.match(self._data.id))
+        return bool(regexp.match(str(self._data.id)))
 
     def parenthesis(self, operands) -> bool:
         return operands[0]
 
-    def value(self, item) -> list:
+    def value(self, item) -> UrnId:
         urnid_item = UrnId.assure_urn_id(urn=self._urn, id=item[0])
         return urnid_item
 

--- a/tests/unit/reqstool/common/test_urn_id.py
+++ b/tests/unit/reqstool/common/test_urn_id.py
@@ -1,0 +1,26 @@
+# Copyright © LFV
+
+from reqstool.common.dataclasses.urn_id import UrnId
+
+
+def test_assure_urn_id_bare_id_returns_urn_id():
+    result = UrnId.assure_urn_id(urn="ms-001", id="REQ_001")
+    assert isinstance(result, UrnId)
+    assert result.urn == "ms-001"
+    assert result.id == "REQ_001"
+    assert str(result) == "ms-001:REQ_001"
+
+
+def test_assure_urn_id_qualified_id_uses_embedded_urn():
+    result = UrnId.assure_urn_id(urn="ms-001", id="other-urn:REQ_999")
+    assert isinstance(result, UrnId)
+    assert result.urn == "other-urn"
+    assert result.id == "REQ_999"
+    assert str(result) == "other-urn:REQ_999"
+
+
+def test_assure_urn_id_qualified_same_urn():
+    result = UrnId.assure_urn_id(urn="ms-001", id="ms-001:REQ_042")
+    assert isinstance(result, UrnId)
+    assert result.urn == "ms-001"
+    assert result.id == "REQ_042"

--- a/tests/unit/reqstool/expression_languages/test_requirements_el.py
+++ b/tests/unit/reqstool/expression_languages/test_requirements_el.py
@@ -3,6 +3,7 @@
 import pytest
 from reqstool_python_decorators.decorators.decorators import SVCs
 
+from reqstool.common.dataclasses.urn_id import UrnId
 from reqstool.expression_languages.requirements_el import RequirementsELTransformer
 from reqstool.models.requirements import SIGNIFANCETYPES, RequirementData
 
@@ -21,7 +22,7 @@ def create_tree():
 def requirement_data():
     def closure(req_id: str):
         return RequirementData(
-            id=req_id,
+            id=UrnId.instance(req_id),
             title="some title",
             significance=SIGNIFANCETYPES("shall"),
             description="some description",

--- a/tests/unit/reqstool/expression_languages/test_svcs_el.py
+++ b/tests/unit/reqstool/expression_languages/test_svcs_el.py
@@ -3,6 +3,7 @@
 import pytest
 from reqstool_python_decorators.decorators.decorators import SVCs
 
+from reqstool.common.dataclasses.urn_id import UrnId
 from reqstool.expression_languages.svcs_el import SVCsELTransformer
 from reqstool.models.svcs import VERIFICATIONTYPES, SVCData
 
@@ -20,7 +21,7 @@ def create_tree():
 def svc_data():
     def closure(svc_id: str):
         return SVCData(
-            id=svc_id,
+            id=UrnId.instance(svc_id),
             requirement_ids=["SVC_001", "SVC_002"],
             title="some title",
             description="some description",


### PR DESCRIPTION
## Summary

- `UrnId.assure_urn_id` returned a raw `str`, causing silent type mismatches in `comp_id_equals`/`comp_id_not_equals` where `self._data.id` is `UrnId` in production — comparisons always returned `False`
- `assure_urn_id` now returns `UrnId`: delegates to `UrnId.instance()` when the id already contains `:`, otherwise constructs `UrnId(urn=urn, id=id)` directly
- `comp_id_regex_equals` fixed to use `str(self._data.id)` — `re.match` requires a string, and `UrnId.__str__` returns `"urn:id"`
- `generate_json.py`: `UrnIdHandler.flatten` wraps result in `str()` to preserve JSON-serializable output
- EL test fixtures updated to pass `UrnId.instance(id)` matching production model types (`SVCData.id: UrnId`, `RequirementData.id: UrnId`)
- New unit tests for `assure_urn_id` in `tests/unit/reqstool/common/test_urn_id.py`

Closes #251

## Test plan

- [x] `hatch run dev:pytest tests/` — 111 passed, 2 deselected (3 new tests added)