### PR TITLE
fix: remove @dataclass from Utils and lazy-init TempDirectoryUtil.tmpdir (#252)

### DIFF
--- a/src/reqstool/common/utils.py
+++ b/src/reqstool/common/utils.py
@@ -3,7 +3,6 @@
 import logging
 import os
 import tempfile
-from dataclasses import dataclass
 from importlib.metadata import version
 from itertools import chain
 from pathlib import Path
@@ -19,7 +18,6 @@ from reqstool.models.requirements import VARIANTS, RequirementData
 from reqstool.models.svcs import SVCData
 
 
-@dataclass(kw_only=True)
 class Utils:
 
     is_installed_package: bool = True
@@ -314,18 +312,24 @@ class Utils:
 
 
 class TempDirectoryUtil:
-    tmpdir: tempfile.TemporaryDirectory = tempfile.TemporaryDirectory()
+    tmpdir: tempfile.TemporaryDirectory = None
     count: int = 0
 
     @staticmethod
+    def _get_tmpdir() -> tempfile.TemporaryDirectory:
+        if TempDirectoryUtil.tmpdir is None:
+            TempDirectoryUtil.tmpdir = tempfile.TemporaryDirectory()
+        return TempDirectoryUtil.tmpdir
+
+    @staticmethod
     def get_path() -> Path:
-        return Path(TempDirectoryUtil.tmpdir.name)
+        return Path(TempDirectoryUtil._get_tmpdir().name)
 
     @staticmethod
     def get_suffix_path(suffix: str) -> Path:
         new_path = Path(
             os.path.join(
-                TempDirectoryUtil.tmpdir.name,
+                TempDirectoryUtil._get_tmpdir().name,
                 str(TempDirectoryUtil.count),
                 suffix,
             )


### PR DESCRIPTION
## Summary
- Remove `@dataclass(kw_only=True)` from `Utils` — the class has no instance fields, so the decorator was unnecessary overhead
- Remove the now-unused `from dataclasses import dataclass` import
- Change `TempDirectoryUtil.tmpdir` class attribute from eager `tempfile.TemporaryDirectory()` to `None`
- Add `_get_tmpdir()` lazy accessor that creates the `TemporaryDirectory` on first call
- Update `get_path()` and `get_suffix_path()` to use `_get_tmpdir()`

Fixes #252

## Test plan
- [x] `hatch run dev:flake8 src/reqstool/common/utils.py` — clean
- [x] `hatch run dev:black src/reqstool/common/utils.py` — no changes
- [x] `hatch run dev:pytest tests/` — 158 passed