### PR TITLE
fix: remaining is/is not enum comparisons and duplicate field assignment (#222)

### DIFF
--- a/src/reqstool/model_generators/combined_indexed_dataset_generator.py
+++ b/src/reqstool/model_generators/combined_indexed_dataset_generator.py
@@ -102,7 +102,7 @@ class CombinedIndexedDatasetGenerator:
 
     def process(self):
         # if initial urn is not a system then do nothing
-        self.__initial_urn_is_variant_ms = self.initial_urn_is_ms = (
+        self.initial_urn_is_ms = (
             self._crd.raw_datasets[self._crd.initial_model_urn].requirements_data.metadata.variant
             == VARIANTS.MICROSERVICE
         )
@@ -333,7 +333,7 @@ class CombinedIndexedDatasetGenerator:
 
         # for each import urn where it accessible by initial urn
         for import_urn in self._crd.parsing_graph[urn]:
-            if self._crd.raw_datasets[import_urn].requirements_data.metadata.variant is VARIANTS.MICROSERVICE:
+            if self._crd.raw_datasets[import_urn].requirements_data.metadata.variant == VARIANTS.MICROSERVICE:
                 continue
 
             logging.debug(f"Applying requirements filters for import urn {import_urn}")
@@ -475,7 +475,7 @@ class CombinedIndexedDatasetGenerator:
 
         # for each import urn in the initial urn
         for import_urn in self._crd.parsing_graph[urn]:
-            if self._crd.raw_datasets[import_urn].requirements_data.metadata.variant is VARIANTS.MICROSERVICE:
+            if self._crd.raw_datasets[import_urn].requirements_data.metadata.variant == VARIANTS.MICROSERVICE:
                 continue
 
             logging.debug(f"Applying svcs filters for import urn {import_urn}")

--- a/src/reqstool/model_generators/combined_raw_datasets_generator.py
+++ b/src/reqstool/model_generators/combined_raw_datasets_generator.py
@@ -184,8 +184,8 @@ class CombinedRawDatasetsGenerator:
             self.__initial_source_type = rmg.requirements_data.metadata.variant
 
         if (
-            rmg.requirements_data.metadata.variant is VARIANTS.SYSTEM
-            or rmg.requirements_data.metadata.variant is VARIANTS.MICROSERVICE
+            rmg.requirements_data.metadata.variant == VARIANTS.SYSTEM
+            or rmg.requirements_data.metadata.variant == VARIANTS.MICROSERVICE
         ):
             # parse file sources other than requirements.yml
             annotations_data, svcs_data, automated_tests, mvrs_data = self.__parse_source_other(
@@ -247,7 +247,7 @@ class CombinedRawDatasetsGenerator:
             ).model
 
             # requirement annotations (impls) - only for microservices
-            if rmg.requirements_data.metadata.variant is not VARIANTS.MICROSERVICE:
+            if rmg.requirements_data.metadata.variant != VARIANTS.MICROSERVICE:
                 assert not annotations_data.implementations
 
         return annotations_data, svcs_data, automated_tests, mvrs_data


### PR DESCRIPTION
## Summary
- Replace 5 residual `is`/`is not` VARIANTS enum comparisons with `==`/`!=`:
  - `combined_indexed_dataset_generator.py` lines 336, 478
  - `combined_raw_datasets_generator.py` lines 187, 188, 250
- Remove dead private alias `self.__initial_urn_is_variant_ms` from the double assignment at line 105 — the name was set but never read; only `self.initial_urn_is_ms` is kept

Closes #222 (all other items from that issue were fixed in PRs #248, #250, #251, #252, #254, and earlier commits #240–#243)

## Test plan
- [x] `hatch run dev:flake8` — clean
- [x] `hatch run dev:black` — no changes
- [x] `hatch run dev:pytest tests/` — 158 passed