### PR TITLE
chore: update GitHub org references from Luftfartsverket to reqstool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ ARG REQSTOOL_VERSION
 
 LABEL org.opencontainers.image.title="reqstool"
 LABEL org.opencontainers.image.description="This is custom Docker Image for reqstool."
-LABEL org.opencontainers.image.authors="info@lfv.se"
-LABEL org.opencontainers.image.vendor="LFV"
-LABEL org.opencontainers.image.documentation="https://github.com/Luftfartsverket/reqstool-client/blob/main/README.md"
-LABEL org.opencontainers.image.source="https://github.com/Luftfartsverket/reqstool-client"
-LABEL org.opencontainers.image.url="https://github.com/Luftfartsverket/reqstool-client"
+LABEL org.opencontainers.image.authors=""
+LABEL org.opencontainers.image.vendor="reqstool"
+LABEL org.opencontainers.image.documentation="https://github.com/reqstool/reqstool-client/blob/main/README.md"
+LABEL org.opencontainers.image.source="https://github.com/reqstool/reqstool-client"
+LABEL org.opencontainers.image.url="https://github.com/reqstool/reqstool-client"
 
 RUN pip install --no-cache-dir "reqstool==${REQSTOOL_VERSION}"
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 
-[![Commit Activity](https://img.shields.io/github/commit-activity/m/Luftfartsverket/reqstool-client?label=commits&style=for-the-badge)](https://github.com/Luftfartsverket/reqstool-client/pulse)
-[![GitHub Issues](https://img.shields.io/github/issues/Luftfartsverket/reqstool-client?style=for-the-badge&logo=github)](https://github.com/Luftfartsverket/reqstool-client/issues)
-[![License](https://img.shields.io/github/license/Luftfartsverket/reqstool-client?style=for-the-badge&logo=opensourceinitiative)](https://opensource.org/license/mit/)
-[![Build](https://img.shields.io/github/actions/workflow/status/Luftfartsverket/reqstool-client/build.yml?style=for-the-badge&logo=github)](https://github.com/Luftfartsverket/reqstool-client/actions/workflows/build.yml)
-[![Static Badge](https://img.shields.io/badge/Documentation-blue?style=for-the-badge&link=docs)](https://luftfartsverket.github.io/reqstool-client/reqstool-client/0.3.0/index.html)
-[![GitHub Discussions](https://img.shields.io/github/discussions/Luftfartsverket/reqstool-client?style=for-the-badge&logo=github)](https://github.com/Luftfartsverket/reqstool-client/discussions)
+[![Commit Activity](https://img.shields.io/github/commit-activity/m/reqstool/reqstool-client?label=commits&style=for-the-badge)](https://github.com/reqstool/reqstool-client/pulse)
+[![GitHub Issues](https://img.shields.io/github/issues/reqstool/reqstool-client?style=for-the-badge&logo=github)](https://github.com/reqstool/reqstool-client/issues)
+[![License](https://img.shields.io/github/license/reqstool/reqstool-client?style=for-the-badge&logo=opensourceinitiative)](https://opensource.org/license/mit/)
+[![Build](https://img.shields.io/github/actions/workflow/status/reqstool/reqstool-client/build.yml?style=for-the-badge&logo=github)](https://github.com/reqstool/reqstool-client/actions/workflows/build.yml)
+[![Static Badge](https://img.shields.io/badge/Documentation-blue?style=for-the-badge&link=docs)](https://reqstool.github.io/reqstool-client/reqstool-client/0.3.0/index.html)
+[![GitHub Discussions](https://img.shields.io/github/discussions/reqstool/reqstool-client?style=for-the-badge&logo=github)](https://github.com/reqstool/reqstool-client/discussions)
 
 
 # Reqstool Client
@@ -45,7 +45,7 @@ Use `-h/--help` for more information about each command and location.
 
 ## Documentation
 
-For full documentation cane be found [here](https://luftfartsverket.github.io/reqstool-docs/reqstool-client/0.3.0/index.html).
+For full documentation cane be found [here](https://reqstool.github.io/reqstool-docs/reqstool-client/0.3.0/index.html).
 
 ## Contributing
 

--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -2,7 +2,7 @@
 
 site:
   title: Reqstool Documentation
-  url: https://github.com/luftfartsverket/reqstool-client
+  url: https://github.com/reqstool/reqstool-client
   start_page: reqstool-client::index.adoc
 
 content:

--- a/docs/examples/requirements/manual_verification_results.yml
+++ b/docs/examples/requirements/manual_verification_results.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
 
 results:
   - id: # alphanumerical

--- a/docs/examples/requirements/requirements_external.yml
+++ b/docs/examples/requirements/requirements_external.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: sys-ext # unique resource name

--- a/docs/examples/requirements/requirements_microservice.yml
+++ b/docs/examples/requirements/requirements_microservice.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: sys-ed254-mp # unique resource name

--- a/docs/examples/requirements/requirements_system.yml
+++ b/docs/examples/requirements/requirements_system.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: sys-ed254 # unique resource name

--- a/docs/examples/requirements/software_verification_cases.yml
+++ b/docs/examples/requirements/software_verification_cases.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
 
 filters:
   sys001:

--- a/docs/modules/ROOT/pages/data.adoc
+++ b/docs/modules/ROOT/pages/data.adoc
@@ -133,7 +133,7 @@ The tree below shows where the dynamic files will reside after the Maven project
 [[maven-artifact-zip-directory-structure]]
 === Maven Artifact Zip Directory Structure
 
-In order to produce a Maven Artifact Zip, you will need to incorporate the https://github.com/Luftfartsverket/reqstool-java-maven-plugin[Reqstool Java Maven Plugin] into your build process. 
+In order to produce a Maven Artifact Zip, you will need to incorporate the https://github.com/reqstool/reqstool-java-maven-plugin[Reqstool Java Maven Plugin] into your build process. 
 
 During the build process, the plugin creates a zipfile with the static and dynamic files. The zipfile will be named like <<project-id>>-<<version>>-reqstool.zip and will be published under the target/reqstool folder.
 The plugin will also combine the svcs_annotations.yml and the equirements_annotations.yml into one yml file called annotations.yml.
@@ -179,7 +179,7 @@ The tree below shows where the dynamic files will reside after a Hatch or Poetry
 [[hatch-poetry-pypi-package-directory-structure]]
 === Python Package Directory Structure
 
-In order to run reqstool directly on or from the tar.gz file, a custom reqstool_config.yml is added to the tar.gz file by incorporating the https://github.com/luftfartsverket/reqstool-python-hatch-plugin[Reqstool Python Hatch Plugin] or the https://github.com/luftfartsverket/reqstool-python-poetry-plugin[Reqstool Python Poetry Plugin] into your build process. 
+In order to run reqstool directly on or from the tar.gz file, a custom reqstool_config.yml is added to the tar.gz file by incorporating the https://github.com/reqstool/reqstool-python-hatch-plugin[Reqstool Python Hatch Plugin] or the https://github.com/reqstool/reqstool-python-poetry-plugin[Reqstool Python Poetry Plugin] into your build process. 
 
 During the build process, the plugin creates a custom reqstool_config.yml file with paths based on the tar.gz file structure to the static and dynamic files. The reqstool_config.yml file will be located in the root directory of the tar.gz file.
 
@@ -248,7 +248,7 @@ If no authentication is required in order to access the repository, the field `e
 ```yaml
 imports:
   git:
-    - url: https://github.com/Luftfartsverket/reqstool-demo
+    - url: https://github.com/reqstool/reqstool-demo
       branch: main
       path: docs/reqstool
       env_token: SECRET_TOKEN
@@ -264,7 +264,7 @@ To import content from other sources (systems) using Maven.
 ```yaml
 imports:
   maven:
-    - url: https://maven.pkg.github.com/Luftfartsverket/reqstool-client
+    - url: https://maven.pkg.github.com/reqstool/reqstool-client
       group_id: se.lfv.reqstool.testdata
       artifact_id: reqstool-testdata-test-basic-ms101
       path: ""
@@ -293,7 +293,7 @@ imports:
   local:
     - path: ../sys-001
   git:
-    - url: https://github.com/Luftfartsverket/reqstool-demo
+    - url: https://github.com/reqstool/reqstool-demo
       branch: main
       path: docs/reqstool
 ```

--- a/docs/modules/ROOT/pages/file_and_directory_set.adoc
+++ b/docs/modules/ROOT/pages/file_and_directory_set.adoc
@@ -1,11 +1,11 @@
 == Standard File and Directory Set
 
-All files have a JSON Schema: https://github.com/Luftfartsverket/reqstool-client/tree/main/src/reqstool/resources/schemas/v1
+All files have a JSON Schema: https://github.com/reqstool/reqstool-client/tree/main/src/reqstool/resources/schemas/v1
 
 For examples see:
 
-* docs/examples https://github.com/luftfartsverket/reqstool-client/tree/main/docs/examples/requirements[examples]
-* unit tests: https://github.com/luftfartsverket/reqstool-client/tree/main/tests/resources/test_data/data/local[test data]
+* docs/examples https://github.com/reqstool/reqstool-client/tree/main/docs/examples/requirements[examples]
+* unit tests: https://github.com/reqstool/reqstool-client/tree/main/tests/resources/test_data/data/local[test data]
 
 [[reqstool_config]]
 === reqstool_config.yml
@@ -22,7 +22,7 @@ If no reqstool_config.yml file is present in the folder that contains the xref:d
 If you are using a regular xref:data.adoc#java-maven-directory-structure[Maven] project, It is recommended to let all the xref:data.adoc#static-directory-structure[static files] be placed in a folder in the root of the project called 'requirements'. Your reqstool_config.yml file should also be placed in this folder, and would then only need to include the following:
 
 ```yaml
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
 
 language: java
 build: maven
@@ -34,7 +34,7 @@ Below is an example on how to change the default paths to the required *.yml fil
 In this case the reqstool_config.yml file is two dirs deep from project root.
 
 ```yaml
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
 
 type: java 
 build: maven

--- a/docs/modules/ROOT/pages/how_it_works.adoc
+++ b/docs/modules/ROOT/pages/how_it_works.adoc
@@ -4,8 +4,8 @@ Reqstool generates reports and updates on progression of requirement implementat
 
 In order to use the reqstool, you will need to create a requirements.yml file along with a software_verification_cases.yml and/or a manual_verification_results.yml. 
 
-* Examples: https://github.com/Luftfartsverket/reqstool-client/tree/main/docs/modules/examples/partials/requirements
-* Demo: https://github.com/Luftfartsverket/reqstool-demo
+* Examples: https://github.com/reqstool/reqstool-client/tree/main/docs/modules/examples/partials/requirements
+* Demo: https://github.com/reqstool/reqstool-demo
 
 === How it works
 
@@ -105,7 +105,7 @@ Reqstool relies on it's annotation framework in order to couple Requirements and
 
 In order to couple Requirements and Software Verification Cases you will need to install and import a Reqstool annotation framework for your specific project. 
 
-Currently https://github.com/luftfartsverket/reqstool-java-annotations[Java] and https://github.com/luftfartsverket/reqstool-python-decorators[Python] is supported. Please read through those projects installation instructions in order to use them properly.  
+Currently https://github.com/reqstool/reqstool-java-annotations[Java] and https://github.com/reqstool/reqstool-python-decorators[Python] is supported. Please read through those projects installation instructions in order to use them properly.  
 
 Whit the correct annotation framework installed, you'll use the `@Requirements` annotation to couple a specific requirement to a piece of code. 
 In this example, the requirement with id `REQ_111` is coupled with the function somefunction(). This is also possible to do on a class level if that's desired. 

--- a/docs/modules/ROOT/pages/quickstart.adoc
+++ b/docs/modules/ROOT/pages/quickstart.adoc
@@ -1,6 +1,6 @@
 == Quickstart
 
-. Create a requirements.yml file (see https://github.com/luftfartsverket/reqstool-client/blob/main/docs/examples/requirements/requirements_microservice.yml[example] or https://github.com/luftfartsverket/reqstool-client/blob/main/src/reqstool/resources/schemas/v1/requirements.schema.json[JSON Schema])
+. Create a requirements.yml file (see https://github.com/reqstool/reqstool-client/blob/main/docs/examples/requirements/requirements_microservice.yml[example] or https://github.com/reqstool/reqstool-client/blob/main/src/reqstool/resources/schemas/v1/requirements.schema.json[JSON Schema])
 . Add annotations to your code
 . Add parsing of Reqstool annotations to your build 
 . Run `reqstool status` xref:usage.adoc#status[here]

--- a/docs/modules/ROOT/pages/yml/annotations.adoc
+++ b/docs/modules/ROOT/pages/yml/annotations.adoc
@@ -1,7 +1,7 @@
 [source,yaml]
 ----
 
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json
 ---
 requirement_annotations:
   implementations:

--- a/docs/modules/ROOT/pages/yml/manual_verification_results.adoc
+++ b/docs/modules/ROOT/pages/yml/manual_verification_results.adoc
@@ -1,7 +1,7 @@
 [source,yaml]
 ----
 
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
 
 
 

--- a/docs/modules/ROOT/pages/yml/reqstool_config.adoc
+++ b/docs/modules/ROOT/pages/yml/reqstool_config.adoc
@@ -2,7 +2,7 @@
 ----
 
 
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.json
 
 
 type: custom # custom|java-maven|java-maven-docs|python-pyproject

--- a/docs/modules/ROOT/pages/yml/requirements.adoc
+++ b/docs/modules/ROOT/pages/yml/requirements.adoc
@@ -2,7 +2,7 @@
 ----
 
 
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: sys-ed254-mp # unique resource name

--- a/docs/modules/ROOT/pages/yml/requirements_annotations.adoc
+++ b/docs/modules/ROOT/pages/yml/requirements_annotations.adoc
@@ -2,7 +2,7 @@
 ----
 
 
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json
 ---
 
 requirement_annotations:

--- a/docs/modules/ROOT/pages/yml/requirements_external.adoc
+++ b/docs/modules/ROOT/pages/yml/requirements_external.adoc
@@ -3,7 +3,7 @@
 ----
 
 
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 ---
 metadata:
   urn: sys-ext # unique resource name

--- a/docs/modules/ROOT/pages/yml/requirements_microservice.adoc
+++ b/docs/modules/ROOT/pages/yml/requirements_microservice.adoc
@@ -2,7 +2,7 @@
 ----
 
 
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: sys-ed254-mp # unique resource name

--- a/docs/modules/ROOT/pages/yml/requirements_system.adoc
+++ b/docs/modules/ROOT/pages/yml/requirements_system.adoc
@@ -2,7 +2,7 @@
 ----
 
 
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: sys-ed254 # unique resource name

--- a/docs/modules/ROOT/pages/yml/software_verification_cases.adoc
+++ b/docs/modules/ROOT/pages/yml/software_verification_cases.adoc
@@ -2,7 +2,7 @@
 ----
 
 
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
 
 filters:
   sys001:

--- a/docs/modules/ROOT/pages/yml/svcs_annotations.adoc
+++ b/docs/modules/ROOT/pages/yml/svcs_annotations.adoc
@@ -2,7 +2,7 @@
 ----
 
 
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json
 ---
 requirement_annotations:
   tests:

--- a/docs/modules/examples/partials/requirements/manual_verification_results.yml
+++ b/docs/modules/examples/partials/requirements/manual_verification_results.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
 
 results:
   - id: # alphanumerical

--- a/docs/modules/examples/partials/requirements/reqstool_config.yml
+++ b/docs/modules/examples/partials/requirements/reqstool_config.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
 
 language: java
 build: maven

--- a/docs/modules/examples/partials/requirements/requirements_external.yml
+++ b/docs/modules/examples/partials/requirements/requirements_external.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: sys-ext # unique resource name

--- a/docs/modules/examples/partials/requirements/requirements_microservice.yml
+++ b/docs/modules/examples/partials/requirements/requirements_microservice.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: sys-ed254-mp # unique resource name

--- a/docs/modules/examples/partials/requirements/requirements_system.yml
+++ b/docs/modules/examples/partials/requirements/requirements_system.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: sys-ed254 # unique resource name

--- a/docs/modules/examples/partials/requirements/software_verification_cases.yml
+++ b/docs/modules/examples/partials/requirements/software_verification_cases.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
 
 filters:
   sys001:

--- a/docs/reqstool/manual_verification_results.yml
+++ b/docs/reqstool/manual_verification_results.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
 
 results:
   - id: MVR_001

--- a/docs/reqstool/reqstool_config.yml
+++ b/docs/reqstool/reqstool_config.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
 
 language: python
 build: hatch

--- a/docs/reqstool/requirements.yml
+++ b/docs/reqstool/requirements.yml
@@ -1,10 +1,10 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: reqstool-client
   variant: microservice
   title: Reqstool client
-  url: https://github.com/Luftfartsverket/reqstool-client
+  url: https://github.com/reqstool/reqstool-client
 
 requirements:
   - id: REQ_001
@@ -106,7 +106,7 @@ requirements:
   - id: REQ_017
     title: Parse requirements from a maven artifact
     significance: shall
-    description: "Reqstool client should be able to parse requirements data from a Maven artifact that follows the correct structure described in the documentation. See: https://luftfartsverket.github.io/reqstool-client/reqstool-client/0.3.0/data.html#maven-artifact-zip-directory-structure"
+    description: "Reqstool client should be able to parse requirements data from a Maven artifact that follows the correct structure described in the documentation. See: https://reqstool.github.io/reqstool-client/reqstool-client/0.3.0/data.html#maven-artifact-zip-directory-structure"
     categories: [functional-suitability]
     revision: 0.0.1
   - id: REQ_018

--- a/docs/reqstool/software_verification_cases.yml
+++ b/docs/reqstool/software_verification_cases.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
 
 cases:
   - id: SVC_001

--- a/src/reqstool/resources/schemas/v1/annotations.schema.json
+++ b/src/reqstool/resources/schemas/v1/annotations.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json",
+    "$id": "https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema#",
     "type": "object",
     "additionalProperties": false,

--- a/src/reqstool/resources/schemas/v1/common.schema.json
+++ b/src/reqstool/resources/schemas/v1/common.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/common.schema.json",
+    "$id": "https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/common.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$defs": {
         "filters": {

--- a/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
+++ b/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json",
+    "$id": "https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "additionalProperties": false,

--- a/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
+++ b/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json",
+  "$id": "https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "description": "Configuration for reqstool",

--- a/src/reqstool/resources/schemas/v1/requirements.schema.json
+++ b/src/reqstool/resources/schemas/v1/requirements.schema.json
@@ -1,5 +1,5 @@
 {
-    "id": "https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json",
+    "id": "https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "additionalProperties": false,

--- a/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
+++ b/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json",
+    "$id": "https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "additionalProperties": false,

--- a/tests/integration/reqstool/model_generators/test_included_models_generator.py
+++ b/tests/integration/reqstool/model_generators/test_included_models_generator.py
@@ -31,7 +31,7 @@ def test_basic_git():
     combined_raw_datasets_generator.CombinedRawDatasetsGenerator(
         initial_location=GitLocation(
             env_token=choose_token(),
-            url="https://github.com/luftfartsverket/reqstool-client.git",
+            url="https://github.com/reqstool/reqstool-client.git",
             path="tests/resources/test_data/data/remote/test_standard/test_standard_maven_git/ms-001",
             branch="main",
         ),
@@ -52,7 +52,7 @@ def test_basic_maven():
         # Setup
         initial_location=MavenLocation(
             env_token=choose_token(),
-            url="https://maven.pkg.github.com/Luftfartsverket/reqstool-demo",
+            url="https://maven.pkg.github.com/reqstool/reqstool-demo",
             group_id="se.lfv.reqstool",
             artifact_id="reqstool-demo",
             version="0.0.4",

--- a/tests/resources/test_data/data/local/test_basic/baseline/ms-101/annotations.yml
+++ b/tests/resources/test_data/data/local/test_basic/baseline/ms-101/annotations.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json
 ---
 requirement_annotations:
   implementations:

--- a/tests/resources/test_data/data/local/test_basic/baseline/ms-101/manual_verification_results.yml
+++ b/tests/resources/test_data/data/local/test_basic/baseline/ms-101/manual_verification_results.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
 
 results:
   - id: MVR_201

--- a/tests/resources/test_data/data/local/test_basic/baseline/ms-101/reqstool_config.yml
+++ b/tests/resources/test_data/data/local/test_basic/baseline/ms-101/reqstool_config.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
 
 language: java
 build: maven

--- a/tests/resources/test_data/data/local/test_basic/baseline/ms-101/requirements.yml
+++ b/tests/resources/test_data/data/local/test_basic/baseline/ms-101/requirements.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: ms-101

--- a/tests/resources/test_data/data/local/test_basic/baseline/ms-101/software_verification_cases.yml
+++ b/tests/resources/test_data/data/local/test_basic/baseline/ms-101/software_verification_cases.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
 
 cases:
   - id: SVC_101

--- a/tests/resources/test_data/data/local/test_basic/lifecycle/ms-101/annotations.yml
+++ b/tests/resources/test_data/data/local/test_basic/lifecycle/ms-101/annotations.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json
 ---
 requirement_annotations:
   implementations:

--- a/tests/resources/test_data/data/local/test_basic/lifecycle/ms-101/manual_verification_results.yml
+++ b/tests/resources/test_data/data/local/test_basic/lifecycle/ms-101/manual_verification_results.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
 
 results:
   - id: MVR_201

--- a/tests/resources/test_data/data/local/test_basic/lifecycle/ms-101/reqstool_config.yml
+++ b/tests/resources/test_data/data/local/test_basic/lifecycle/ms-101/reqstool_config.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
 
 language: java
 build: maven

--- a/tests/resources/test_data/data/local/test_basic/lifecycle/ms-101/requirements.yml
+++ b/tests/resources/test_data/data/local/test_basic/lifecycle/ms-101/requirements.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: ms-101

--- a/tests/resources/test_data/data/local/test_basic/lifecycle/ms-101/software_verification_cases.yml
+++ b/tests/resources/test_data/data/local/test_basic/lifecycle/ms-101/software_verification_cases.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
 
 cases:
   - id: SVC_101

--- a/tests/resources/test_data/data/local/test_basic/lifecycle/validation_error/requirements.yml
+++ b/tests/resources/test_data/data/local/test_basic/lifecycle/validation_error/requirements.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: ms-101

--- a/tests/resources/test_data/data/local/test_basic/no_impls/basic/ms-101/annotations.yml
+++ b/tests/resources/test_data/data/local/test_basic/no_impls/basic/ms-101/annotations.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json
 ---
 requirement_annotations:
   implementations:

--- a/tests/resources/test_data/data/local/test_basic/no_impls/basic/ms-101/manual_verification_results.yml
+++ b/tests/resources/test_data/data/local/test_basic/no_impls/basic/ms-101/manual_verification_results.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
 
 results:
   - id: MVR_201

--- a/tests/resources/test_data/data/local/test_basic/no_impls/basic/ms-101/reqstool_config.yml
+++ b/tests/resources/test_data/data/local/test_basic/no_impls/basic/ms-101/reqstool_config.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
 
 language: java
 build: maven

--- a/tests/resources/test_data/data/local/test_basic/no_impls/basic/ms-101/requirements.yml
+++ b/tests/resources/test_data/data/local/test_basic/no_impls/basic/ms-101/requirements.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: ms-101

--- a/tests/resources/test_data/data/local/test_basic/no_impls/basic/ms-101/software_verification_cases.yml
+++ b/tests/resources/test_data/data/local/test_basic/no_impls/basic/ms-101/software_verification_cases.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
 
 cases:
   - id: SVC_101

--- a/tests/resources/test_data/data/local/test_basic/no_impls/with_error/ms-101/annotations.yml
+++ b/tests/resources/test_data/data/local/test_basic/no_impls/with_error/ms-101/annotations.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json
 ---
 requirement_annotations:
   implementations:

--- a/tests/resources/test_data/data/local/test_basic/no_impls/with_error/ms-101/manual_verification_results.yml
+++ b/tests/resources/test_data/data/local/test_basic/no_impls/with_error/ms-101/manual_verification_results.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
 
 results:
   - id: MVR_201

--- a/tests/resources/test_data/data/local/test_basic/no_impls/with_error/ms-101/reqstool_config.yml
+++ b/tests/resources/test_data/data/local/test_basic/no_impls/with_error/ms-101/reqstool_config.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
 
 language: java
 build: maven

--- a/tests/resources/test_data/data/local/test_basic/no_impls/with_error/ms-101/requirements.yml
+++ b/tests/resources/test_data/data/local/test_basic/no_impls/with_error/ms-101/requirements.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 #file://home/u70592/dev/clones/github/reqstool-client/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:

--- a/tests/resources/test_data/data/local/test_basic/no_impls/with_error/ms-101/software_verification_cases.yml
+++ b/tests/resources/test_data/data/local/test_basic/no_impls/with_error/ms-101/software_verification_cases.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
 
 cases:
   - id: SVC_201

--- a/tests/resources/test_data/data/local/test_basic/with_requirements_config/README.md
+++ b/tests/resources/test_data/data/local/test_basic/with_requirements_config/README.md
@@ -1,10 +1,10 @@
 
-[![Commit Activity](https://img.shields.io/github/commit-activity/m/Luftfartsverket/reqstool-client?label=commits&style=for-the-badge)](https://github.com/Luftfartsverket/reqstool-client/pulse)
-[![GitHub Issues](https://img.shields.io/github/issues/Luftfartsverket/reqstool-client?style=for-the-badge&logo=github)](https://github.com/Luftfartsverket/reqstool-client/issues)
-[![License](https://img.shields.io/github/license/Luftfartsverket/reqstool-client?style=for-the-badge&logo=opensourceinitiative)](https://opensource.org/license/mit/)
-[![Build](https://img.shields.io/github/actions/workflow/status/Luftfartsverket/reqstool-client/build.yml?style=for-the-badge&logo=github)](https://github.com/Luftfartsverket/reqstool-client/actions/workflows/build.yml)
-[![Static Badge](https://img.shields.io/badge/Documentation-blue?style=for-the-badge&link=docs)](https://luftfartsverket.github.io/reqstool-client/reqstool-client/0.3.0/index.html)
-[![GitHub Discussions](https://img.shields.io/github/discussions/Luftfartsverket/reqstool-client?style=for-the-badge&logo=github)](https://github.com/Luftfartsverket/reqstool-client/discussions)
+[![Commit Activity](https://img.shields.io/github/commit-activity/m/reqstool/reqstool-client?label=commits&style=for-the-badge)](https://github.com/reqstool/reqstool-client/pulse)
+[![GitHub Issues](https://img.shields.io/github/issues/reqstool/reqstool-client?style=for-the-badge&logo=github)](https://github.com/reqstool/reqstool-client/issues)
+[![License](https://img.shields.io/github/license/reqstool/reqstool-client?style=for-the-badge&logo=opensourceinitiative)](https://opensource.org/license/mit/)
+[![Build](https://img.shields.io/github/actions/workflow/status/reqstool/reqstool-client/build.yml?style=for-the-badge&logo=github)](https://github.com/reqstool/reqstool-client/actions/workflows/build.yml)
+[![Static Badge](https://img.shields.io/badge/Documentation-blue?style=for-the-badge&link=docs)](https://reqstool.github.io/reqstool-client/reqstool-client/0.3.0/index.html)
+[![GitHub Discussions](https://img.shields.io/github/discussions/reqstool/reqstool-client?style=for-the-badge&logo=github)](https://github.com/reqstool/reqstool-client/discussions)
 
 
 # Reqstool Client

--- a/tests/resources/test_data/data/local/test_basic/with_requirements_config/ms-101/reqstool_config.yml
+++ b/tests/resources/test_data/data/local/test_basic/with_requirements_config/ms-101/reqstool_config.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
 
 language: java
 build: maven

--- a/tests/resources/test_data/data/local/test_errors/ms-101/annotations.yml
+++ b/tests/resources/test_data/data/local/test_errors/ms-101/annotations.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json
 ---
 requirement_annotations:
   implementations:

--- a/tests/resources/test_data/data/local/test_errors/ms-101/manual_verification_results.yml
+++ b/tests/resources/test_data/data/local/test_errors/ms-101/manual_verification_results.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
 
 results:
   - id: MVR_201

--- a/tests/resources/test_data/data/local/test_errors/ms-101/reqstool_config.yml
+++ b/tests/resources/test_data/data/local/test_errors/ms-101/reqstool_config.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
 
 language: java
 build: maven

--- a/tests/resources/test_data/data/local/test_errors/ms-101/requirements.yml
+++ b/tests/resources/test_data/data/local/test_errors/ms-101/requirements.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: ms-101

--- a/tests/resources/test_data/data/local/test_errors/ms-101/software_verification_cases.yml
+++ b/tests/resources/test_data/data/local/test_errors/ms-101/software_verification_cases.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
 
 cases:
   - id: SVC_101

--- a/tests/resources/test_data/data/local/test_standard/baseline/ms-001/annotations.yml
+++ b/tests/resources/test_data/data/local/test_standard/baseline/ms-001/annotations.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json
 ---
 requirement_annotations:
   implementations:

--- a/tests/resources/test_data/data/local/test_standard/baseline/ms-001/manual_verification_results.yml
+++ b/tests/resources/test_data/data/local/test_standard/baseline/ms-001/manual_verification_results.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
 
 results:
   - id: MVR_201

--- a/tests/resources/test_data/data/local/test_standard/baseline/ms-001/reqstool_config.yml
+++ b/tests/resources/test_data/data/local/test_standard/baseline/ms-001/reqstool_config.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
 
 language: java
 build: maven

--- a/tests/resources/test_data/data/local/test_standard/baseline/ms-001/requirements.yml
+++ b/tests/resources/test_data/data/local/test_standard/baseline/ms-001/requirements.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: ms-001

--- a/tests/resources/test_data/data/local/test_standard/baseline/ms-001/software_verification_cases.yml
+++ b/tests/resources/test_data/data/local/test_standard/baseline/ms-001/software_verification_cases.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
 
 filters:
   sys-001:

--- a/tests/resources/test_data/data/local/test_standard/baseline/sys-001/ext-001/requirements.yml
+++ b/tests/resources/test_data/data/local/test_standard/baseline/sys-001/ext-001/requirements.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: ext-001

--- a/tests/resources/test_data/data/local/test_standard/baseline/sys-001/ext-002/requirements.yml
+++ b/tests/resources/test_data/data/local/test_standard/baseline/sys-001/ext-002/requirements.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
     urn: ext-002

--- a/tests/resources/test_data/data/local/test_standard/baseline/sys-001/requirements.yml
+++ b/tests/resources/test_data/data/local/test_standard/baseline/sys-001/requirements.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: sys-001

--- a/tests/resources/test_data/data/local/test_standard/baseline/sys-001/software_verification_cases.yml
+++ b/tests/resources/test_data/data/local/test_standard/baseline/sys-001/software_verification_cases.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
 
 cases:
   - id: SVC_sys001_500

--- a/tests/resources/test_data/data/local/test_standard/empty_ms/ms-001/annotations.yml
+++ b/tests/resources/test_data/data/local/test_standard/empty_ms/ms-001/annotations.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json
 ---
 requirement_annotations:
   implementations:

--- a/tests/resources/test_data/data/local/test_standard/empty_ms/ms-001/reqstool_config.yml
+++ b/tests/resources/test_data/data/local/test_standard/empty_ms/ms-001/reqstool_config.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
 
 language: java
 build: maven

--- a/tests/resources/test_data/data/local/test_standard/empty_ms/ms-001/requirements.yml
+++ b/tests/resources/test_data/data/local/test_standard/empty_ms/ms-001/requirements.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: ms-001

--- a/tests/resources/test_data/data/local/test_standard/empty_ms/sys-001/ext-001/requirements.yml
+++ b/tests/resources/test_data/data/local/test_standard/empty_ms/sys-001/ext-001/requirements.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: ext-001

--- a/tests/resources/test_data/data/local/test_standard/empty_ms/sys-001/ext-002/requirements.yml
+++ b/tests/resources/test_data/data/local/test_standard/empty_ms/sys-001/ext-002/requirements.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: ext-002

--- a/tests/resources/test_data/data/local/test_standard/empty_ms/sys-001/manual_verification_results.yml
+++ b/tests/resources/test_data/data/local/test_standard/empty_ms/sys-001/manual_verification_results.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
 
 results:
   - id: MVR_201

--- a/tests/resources/test_data/data/local/test_standard/empty_ms/sys-001/requirements.yml
+++ b/tests/resources/test_data/data/local/test_standard/empty_ms/sys-001/requirements.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: sys-001

--- a/tests/resources/test_data/data/local/test_standard/empty_ms/sys-001/software_verification_cases.yml
+++ b/tests/resources/test_data/data/local/test_standard/empty_ms/sys-001/software_verification_cases.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
 
 cases:
   - id: SVC_sys001_010

--- a/tests/resources/test_data/data/remote/test_standard/test_standard_maven_git/ms-001/reqstool_config.yml
+++ b/tests/resources/test_data/data/remote/test_standard/test_standard_maven_git/ms-001/reqstool_config.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
 
 language: java
 build: maven

--- a/tests/resources/test_data/data/remote/test_standard/test_standard_maven_git/sys-001/requirements.yml
+++ b/tests/resources/test_data/data/remote/test_standard/test_standard_maven_git/sys-001/requirements.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: sys-001
@@ -20,7 +20,7 @@ implementations:
   git:
     - branch: main
       env_token: GITLAB_TOKEN
-      url: "https://github.com/Luftfartsverket/requirements-tool-testdata.git"
+      url: "https://github.com/reqstool/requirements-tool-testdata.git"
       path: "data/remote/test_standard/test_standard_maven_git/ms-001"
 
   local:

--- a/tests/resources/unit/reqstool/model_generators/test_annotations_model_generator/test_annotations_model_generator/annotations.yml
+++ b/tests/resources/unit/reqstool/model_generators/test_annotations_model_generator/test_annotations_model_generator/annotations.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/annotations.schema.json
 ---
 requirement_annotations:
   implementations:

--- a/tests/resources/unit/reqstool/model_generators/test_mvrs_model_generator/test_mvrs_model_generator/manual_verification_results.yml
+++ b/tests/resources/unit/reqstool/model_generators/test_mvrs_model_generator/test_mvrs_model_generator/manual_verification_results.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
 
 results:
   - id: MVR_001

--- a/tests/resources/unit/reqstool/model_generators/test_requirements_model_generator/test_external_requirements_model_generator/requirements.yml
+++ b/tests/resources/unit/reqstool/model_generators/test_requirements_model_generator/test_external_requirements_model_generator/requirements.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: ext-001

--- a/tests/resources/unit/reqstool/model_generators/test_requirements_model_generator/test_lifecycle_variable_model_generator/requirements.yml
+++ b/tests/resources/unit/reqstool/model_generators/test_requirements_model_generator/test_lifecycle_variable_model_generator/requirements.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: ms-001

--- a/tests/resources/unit/reqstool/model_generators/test_requirements_model_generator/test_microservice_requirements_model_generator/requirements.yml
+++ b/tests/resources/unit/reqstool/model_generators/test_requirements_model_generator/test_microservice_requirements_model_generator/requirements.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: ms-001

--- a/tests/resources/unit/reqstool/model_generators/test_requirements_model_generator/test_rational_optional_model_generator/requirements.yml
+++ b/tests/resources/unit/reqstool/model_generators/test_requirements_model_generator/test_rational_optional_model_generator/requirements.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: ext-001

--- a/tests/resources/unit/reqstool/model_generators/test_requirements_model_generator/test_system_requirements_model_generator/requirements.yml
+++ b/tests/resources/unit/reqstool/model_generators/test_requirements_model_generator/test_system_requirements_model_generator/requirements.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
 
 metadata:
   urn: sys-001

--- a/tests/resources/unit/reqstool/model_generators/test_svcs_model_generator/test_lifecycle_variable_model_generator/software_verification_cases.yml
+++ b/tests/resources/unit/reqstool/model_generators/test_svcs_model_generator/test_lifecycle_variable_model_generator/software_verification_cases.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
 
 cases:
   - id: SVC_001

--- a/tests/resources/unit/reqstool/model_generators/test_svcs_model_generator/test_svcs_model_generator/software_verification_cases.yml
+++ b/tests/resources/unit/reqstool/model_generators/test_svcs_model_generator/test_svcs_model_generator/software_verification_cases.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
 
 cases:
   - id: SVC_001

--- a/tests/unit/reqstool/models/test_implementations.py
+++ b/tests/unit/reqstool/models/test_implementations.py
@@ -15,7 +15,7 @@ def git_impl_data() -> GitImplData:
         _current_unresolved=GitLocation(
             env_token="GITLAB_TOKEN",
             branch="main",
-            url="https://github.com/Luftfartsverket/reqstool-client",
+            url="https://github.com/reqstool/reqstool-client",
             path="/examples/README.adoc",
         ),
     )
@@ -50,7 +50,7 @@ def test_git_impl_data(git_impl_data):
     assert git_impl_data.parent is None
     assert git_impl_data.current.env_token == "GITLAB_TOKEN"
     assert git_impl_data.current.branch == "main"
-    assert git_impl_data.current.url == "https://github.com/Luftfartsverket/reqstool-client"
+    assert git_impl_data.current.url == "https://github.com/reqstool/reqstool-client"
     assert git_impl_data.current.path == "/examples/README.adoc"
 
 


### PR DESCRIPTION
## Summary
- Replace all hardcoded `Luftfartsverket` GitHub org references with `reqstool`
- Covers schemas (`$id` URLs), docs (AsciiDoc + YAML), test fixtures, Dockerfile labels, README badges, and integration/unit test URLs

## Test plan
- [ ] Schema `$id` URLs point to the correct new location
- [ ] Integration tests reference the correct GitHub org