### PR TITLE
fix: validate archive structure before extraction and add return-type annotations

### DIFF
--- a/src/reqstool/common/utils.py
+++ b/src/reqstool/common/utils.py
@@ -34,9 +34,9 @@ class Utils:
     def extract_zip(zip_path: str, dst_path: str) -> str:
         with ZipFile(zip_path, "r") as zip_ref:
             top_level_dirs = {name.split("/")[0] for name in zip_ref.namelist() if "/" in name}
+            if len(top_level_dirs) != 1:
+                raise ValueError(f"ZIP artifact did not have exactly one top-level directory: {top_level_dirs}")
             zip_ref.extractall(path=dst_path)
-        if len(top_level_dirs) != 1:
-            raise ValueError(f"ZIP artifact did not have exactly one top-level directory: {top_level_dirs}")
         top_level_dir = os.path.join(dst_path, top_level_dirs.pop())
         logging.debug(f"Extracted {zip_path} to {top_level_dir}")
         return top_level_dir
@@ -44,12 +44,10 @@ class Utils:
     @staticmethod
     def extract_targz(targz_path: str, dst_path: str) -> str:
         with tarfile.open(targz_path, "r:gz") as tar_ref:
-            top_level_dirs = {
-                member.name.split("/")[0] for member in tar_ref.getmembers() if member.name.count("/") > 0
-            }
+            top_level_dirs = {member.name.split("/")[0] for member in tar_ref.getmembers() if "/" in member.name}
+            if len(top_level_dirs) != 1:
+                raise ValueError(f"tar.gz artifact did not have exactly one top-level directory: {top_level_dirs}")
             tar_ref.extractall(path=dst_path, filter="data")
-        if len(top_level_dirs) != 1:
-            raise ValueError(f"tar.gz artifact did not have exactly one top-level directory: {top_level_dirs}")
         top_level_dir = os.path.join(dst_path, top_level_dirs.pop())
         logging.debug(f"Extracted {targz_path} to {top_level_dir}")
         return top_level_dir

--- a/src/reqstool/locations/local_maven_location.py
+++ b/src/reqstool/locations/local_maven_location.py
@@ -10,5 +10,5 @@ from reqstool.locations.location import LocationInterface
 class LocalMavenLocation(LocationInterface):
     path: str  # path to a local Maven ZIP artifact (.zip)
 
-    def _make_available_on_localdisk(self, dst_path: str):
+    def _make_available_on_localdisk(self, dst_path: str) -> str:
         return Utils.extract_zip(self.path, dst_path)

--- a/src/reqstool/locations/local_pypi_location.py
+++ b/src/reqstool/locations/local_pypi_location.py
@@ -10,5 +10,5 @@ from reqstool.locations.location import LocationInterface
 class LocalPypiLocation(LocationInterface):
     path: str  # path to a local PyPI sdist tarball (.tar.gz)
 
-    def _make_available_on_localdisk(self, dst_path: str):
+    def _make_available_on_localdisk(self, dst_path: str) -> str:
         return Utils.extract_targz(self.path, dst_path)

--- a/src/reqstool/locations/location.py
+++ b/src/reqstool/locations/location.py
@@ -16,5 +16,5 @@ class LOCATIONTYPES(Enum):
 @dataclass(kw_only=True)
 class LocationInterface(ABC):
     @abstractmethod
-    def _make_available_on_localdisk(self, dst_path: str):
+    def _make_available_on_localdisk(self, dst_path: str) -> str:
         pass


### PR DESCRIPTION
## Summary

Follow-up fixes from the code review of #272 (now merged):

- **Validate-before-extract**: move the `len(top_level_dirs) != 1` guard inside the `with` block, _before_ `extractall()`, in both `extract_zip` and `extract_targz` — prevents partial extraction on disk when validation fails
- **Consistent TAR filter**: standardise `extract_targz` filter from `member.name.count("/") > 0` to `"/" in member.name`, consistent with the ZIP implementation
- **Return-type annotations**: add `-> str` to `LocationInterface._make_available_on_localdisk` (abstract method), `LocalMavenLocation._make_available_on_localdisk`, and `LocalPypiLocation._make_available_on_localdisk`

## Test plan

- [x] `hatch run dev:pytest tests/unit/reqstool/locations/ -q` — all location tests pass (including invalid-archive tests that exercise validate-before-extract)
- [x] `hatch run dev:pytest -q` — full suite passes (168 passed)
- [x] `hatch run dev:black --check src/` — clean
- [x] `hatch run dev:flake8 src/` — clean