### PR TITLE
ci: restrict push trigger to main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ on:
   workflow_call:
   workflow_dispatch:
   push:
+    branches:
+      - main
   pull_request:
     types:
       - opened


### PR DESCRIPTION
## Summary

- Restrict `push` trigger in `build.yml` to only run on the `main` branch
- Prevents duplicate CI runs on PRs (both `push` and `pull_request` were firing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)