### PR TITLE
ci: add renovate auto-approve workflow

### DIFF
--- a/.github/workflows/renovate-approve.yml
+++ b/.github/workflows/renovate-approve.yml
@@ -1,0 +1,11 @@
+name: Renovate auto-approve
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+
+jobs:
+  approve:
+    uses: reqstool/.github/.github/workflows/renovate-approve.yml@main


### PR DESCRIPTION
## Summary

- Add caller workflow for the centralised Renovate auto-approve reusable workflow in [reqstool/.github](https://github.com/reqstool/.github)
- When Renovate opens a PR, this workflow approves it using \`GITHUB_TOKEN\`, satisfying the required-review branch protection rule
- Unblocks Renovate's existing auto-merge setting so PRs merge automatically once checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)