### PR TITLE
ci: fix renovate approve condition to check PR author

### DIFF
--- a/.github/workflows/renovate-approve.yml
+++ b/.github/workflows/renovate-approve.yml
@@ -8,4 +8,5 @@ on:
 
 jobs:
   approve:
+    if: github.event.pull_request.user.login == 'renovate[bot]'
     uses: reqstool/.github/.github/workflows/renovate-approve.yml@main


### PR DESCRIPTION
## Summary

Fix incorrect actor check in the Renovate auto-approve workflow.

**Problem:** `github.actor` reflects who *triggered* the event (e.g. a human reopening a PR), not who authored the PR — so the `if` condition was silently skipping on legitimate Renovate PRs.

**Fix:** Move the condition to the caller and use `github.event.pull_request.user.login` which always reflects the PR author regardless of who triggered the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)