### PR TITLE
ci: fix renovate approve — use pull_request_target and write permissions

### DIFF
--- a/.github/workflows/renovate-approve.yml
+++ b/.github/workflows/renovate-approve.yml
@@ -1,10 +1,13 @@
 name: Renovate auto-approve
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened
+
+permissions:
+  pull-requests: write
 
 jobs:
   approve:


### PR DESCRIPTION
## Summary

Fix the renovate auto-approve workflow which was failing with _"Resource not accessible by integration"_.

**Root cause:** The `pull_request` event provides a read-only `GITHUB_TOKEN` when the workflow is called via `workflow_call`, so the approval write operation is rejected.

**Fix:**
- Switch trigger from `pull_request` → `pull_request_target` (runs in base branch context, has write access; safe because the workflow never checks out PR branch code)
- Add `permissions: pull-requests: write` explicitly at the workflow level

🤖 Generated with [Claude Code](https://claude.com/claude-code)