### PR TITLE
fix: exclude manual SVCs from automated test missing count

### DIFF
--- a/src/reqstool/commands/status/statistics_generator.py
+++ b/src/reqstool/commands/status/statistics_generator.py
@@ -213,8 +213,8 @@ class StatisticsGenerator:
                         test_urn_id = UrnId(urn=urn_id.urn, id=test.fully_qualified_name)
                         results = self.__get_annotated_test_results(urn_id=test_urn_id)
                         automated_test_results.extend(results)
-            else:
-                # No tests found for this SVC - create TestData with missing status
+            elif urn_id in self.cid.svcs and self.cid.svcs[urn_id].verification in EXPECTS_AUTOMATED_TESTS:
+                # Only count as missing if this SVC expects automated tests
                 automated_test_results.append(TestData(fully_qualified_name="", status=TEST_RUN_STATUS.MISSING))
 
         return automated_test_results

--- a/tests/unit/reqstool/commands/status/test_statistics_generator.py
+++ b/tests/unit/reqstool/commands/status/test_statistics_generator.py
@@ -158,7 +158,7 @@ def test_calculate_test_standard_ms001(local_testdata_resources_rootdir_w_path):
                 nr_of_implementations=1,
                 automated_tests_stats=TestStatisticsItem(
                     nr_of_failed_tests=1,
-                    nr_of_missing_automated_tests=1,
+                    nr_of_missing_automated_tests=0,
                     nr_of_missing_manual_tests=0,
                     nr_of_skipped_tests=0,
                     nr_of_passed_tests=2,
@@ -181,7 +181,7 @@ def test_calculate_test_standard_ms001(local_testdata_resources_rootdir_w_path):
                 nr_of_implementations=1,
                 automated_tests_stats=TestStatisticsItem(
                     nr_of_failed_tests=0,
-                    nr_of_missing_automated_tests=1,
+                    nr_of_missing_automated_tests=0,
                     nr_of_missing_manual_tests=0,
                     nr_of_skipped_tests=0,
                     nr_of_passed_tests=1,
@@ -204,7 +204,7 @@ def test_calculate_test_standard_ms001(local_testdata_resources_rootdir_w_path):
                 nr_of_implementations=0,
                 automated_tests_stats=TestStatisticsItem(
                     nr_of_failed_tests=0,
-                    nr_of_missing_automated_tests=2,
+                    nr_of_missing_automated_tests=1,
                     nr_of_missing_manual_tests=0,
                     nr_of_skipped_tests=0,
                     nr_of_passed_tests=1,
@@ -273,7 +273,7 @@ def test_calculate_test_standard_ms001(local_testdata_resources_rootdir_w_path):
                 nr_of_implementations=1,
                 automated_tests_stats=TestStatisticsItem(
                     nr_of_failed_tests=0,
-                    nr_of_missing_automated_tests=1,
+                    nr_of_missing_automated_tests=0,
                     nr_of_missing_manual_tests=0,
                     nr_of_skipped_tests=0,
                     nr_of_passed_tests=1,
@@ -297,7 +297,7 @@ def test_calculate_test_standard_ms001(local_testdata_resources_rootdir_w_path):
             nr_of_failed_automatic_tests=1,
             nr_of_failed_manual_tests=1,
             nr_of_failed_tests=2,
-            nr_of_missing_automated_tests=6,
+            nr_of_missing_automated_tests=2,
             nr_of_missing_manual_tests=2,
             nr_of_passed_automatic_tests=4,
             nr_of_passed_manual_tests=1,
@@ -330,7 +330,7 @@ def test_calculate_empty_standard_ms001(local_testdata_resources_rootdir_w_path)
                 nr_of_implementations=0,
                 automated_tests_stats=TestStatisticsItem(
                     nr_of_failed_tests=0,
-                    nr_of_missing_automated_tests=1,
+                    nr_of_missing_automated_tests=0,
                     nr_of_missing_manual_tests=0,
                     nr_of_skipped_tests=0,
                     nr_of_passed_tests=1,
@@ -353,7 +353,7 @@ def test_calculate_empty_standard_ms001(local_testdata_resources_rootdir_w_path)
                 nr_of_implementations=1,
                 automated_tests_stats=TestStatisticsItem(
                     nr_of_failed_tests=1,
-                    nr_of_missing_automated_tests=1,
+                    nr_of_missing_automated_tests=0,
                     nr_of_missing_manual_tests=0,
                     nr_of_skipped_tests=0,
                     nr_of_passed_tests=2,
@@ -376,7 +376,7 @@ def test_calculate_empty_standard_ms001(local_testdata_resources_rootdir_w_path)
                 nr_of_implementations=1,
                 automated_tests_stats=TestStatisticsItem(
                     nr_of_failed_tests=0,
-                    nr_of_missing_automated_tests=1,
+                    nr_of_missing_automated_tests=0,
                     nr_of_missing_manual_tests=0,
                     nr_of_skipped_tests=0,
                     nr_of_passed_tests=1,
@@ -445,7 +445,7 @@ def test_calculate_empty_standard_ms001(local_testdata_resources_rootdir_w_path)
                 nr_of_implementations=1,
                 automated_tests_stats=TestStatisticsItem(
                     nr_of_failed_tests=0,
-                    nr_of_missing_automated_tests=1,
+                    nr_of_missing_automated_tests=0,
                     nr_of_missing_manual_tests=0,
                     nr_of_skipped_tests=0,
                     nr_of_passed_tests=1,
@@ -465,7 +465,7 @@ def test_calculate_empty_standard_ms001(local_testdata_resources_rootdir_w_path)
         },
         _total_statistics=TotalStatisticsItem(
             nr_of_failed_tests=2,
-            nr_of_missing_automated_tests=5,
+            nr_of_missing_automated_tests=1,
             nr_of_missing_manual_tests=2,
             nr_of_skipped_tests=0,
             nr_of_passed_tests=5,


### PR DESCRIPTION
## Summary

- Manual-test SVCs (e.g. `manual-test` verification type) were incorrectly counted as missing automated tests, inflating the "M" column in the Automated Tests section of the status report
- Now only SVCs with verification types that expect automated tests are counted as missing when no test is found
- Updated unit test expectations to reflect correct missing counts

## Related

- Verified against [reqstool-demo](https://github.com/reqstool/reqstool-demo) with the new `REQ_MISSING_TEST` scenario

## Test plan

- [x] Unit tests updated and passing
- [x] Run `reqstool status local` against reqstool-demo to confirm correct M counts
- [x] Verify manual SVCs no longer show as missing in Automated Tests column

🤖 Generated with [Claude Code](https://claude.com/claude-code)