### PR TITLE
fix: correct exit call and TOCTOU race condition

### DIFF
--- a/src/reqstool/command.py
+++ b/src/reqstool/command.py
@@ -59,8 +59,7 @@ class Command:
 
         directory = os.path.dirname(os.path.abspath(file_path))
 
-        if not os.path.exists(directory):
-            os.makedirs(directory)
+        os.makedirs(directory, exist_ok=True)
 
         return open(file_path, "w")
 

--- a/src/reqstool/model_generators/requirements_model_generator.py
+++ b/src/reqstool/model_generators/requirements_model_generator.py
@@ -88,7 +88,7 @@ class RequirementsModelGenerator:
         urn = self.get_urn_if_available(response.text)
 
         if not SyntaxValidator.is_valid_data(json_schema_type=JsonSchemaTypes.REQUIREMENTS, data=data, urn=urn):
-            sys.data = data, exit(EXIT_CODE_SYNTAX_VALIDATION_ERROR)
+            sys.exit(EXIT_CODE_SYNTAX_VALIDATION_ERROR)
 
         r_metadata: MetaData = self.__parse_metadata(data["metadata"])
 


### PR DESCRIPTION
## Summary
- Fix confusing `sys.data = data, exit(...)` to `sys.exit(...)` in `requirements_model_generator.py:91` — the original code assigned a tuple to `sys.data` as a side effect rather than actually exiting
- Replace check-then-create (`os.path.exists` + `os.makedirs`) with `os.makedirs(exist_ok=True)` in `command.py:62-65` to eliminate a TOCTOU race condition

## Test plan
- [x] All 188 unit tests pass
- [x] Smoke test against reqstool-demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)