### PR TITLE
refactor: rename SIGNIFANCETYPES and clean up type annotations

### DIFF
--- a/src/reqstool/command.py
+++ b/src/reqstool/command.py
@@ -5,7 +5,7 @@ import argparse
 import logging
 import os
 import sys
-from typing import TextIO, Union
+from typing import Optional, TextIO, Union
 
 if __package__ is None or len(__package__) == 0:
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -274,7 +274,7 @@ class Command:
         return args
 
     def _get_initial_source(self, args_source: argparse.Namespace) -> LocationInterface:
-        location: LocationInterface = None
+        location: Optional[LocationInterface] = None
 
         if "maven" in args_source.source:
             location = MavenLocation(

--- a/src/reqstool/commands/generate_json/generate_json.py
+++ b/src/reqstool/commands/generate_json/generate_json.py
@@ -18,7 +18,7 @@ from reqstool.model_generators.combined_indexed_dataset_generator import Combine
 from reqstool.model_generators.combined_raw_datasets_generator import CombinedRawDatasetsGenerator
 from reqstool.models.combined_indexed_dataset import CombinedIndexedDataset
 from reqstool.models.raw_datasets import CombinedRawDataset
-from reqstool.models.requirements import CATEGORIES, SIGNIFANCETYPES, TYPES, VARIANTS
+from reqstool.models.requirements import CATEGORIES, SIGNIFICANCETYPES, TYPES, VARIANTS
 from reqstool.models.svcs import VERIFICATIONTYPES
 from reqstool.models.test_data import TEST_RUN_STATUS
 
@@ -156,7 +156,7 @@ class GenerateJsonCommand:
         jsonpickle.handlers.registry.register(Version, RevisionHandler)
         jsonpickle.handlers.registry.register(CATEGORIES, JsonEnumHandler)
         jsonpickle.handlers.registry.register(LOCATIONTYPES, JsonEnumHandler)
-        jsonpickle.handlers.registry.register(SIGNIFANCETYPES, JsonEnumHandler)
+        jsonpickle.handlers.registry.register(SIGNIFICANCETYPES, JsonEnumHandler)
         jsonpickle.handlers.registry.register(TYPES, JsonEnumHandler)
         jsonpickle.handlers.registry.register(VARIANTS, JsonEnumHandler)
         jsonpickle.handlers.registry.register(VERIFICATIONTYPES, JsonEnumHandler)

--- a/src/reqstool/model_generators/mvrs_model_generator.py
+++ b/src/reqstool/model_generators/mvrs_model_generator.py
@@ -42,7 +42,7 @@ class MVRsModelGenerator:
             mvr = MVRData(
                 id=urn_id,
                 svc_ids=Utils.convert_ids_to_urn_id(ids=result["svc_ids"], urn=self.urn),
-                comment=result["comment"] if "comment" in result else None,
+                comment=result.get("comment"),
                 passed=result["pass"],
             )
 

--- a/src/reqstool/model_generators/requirements_model_generator.py
+++ b/src/reqstool/model_generators/requirements_model_generator.py
@@ -3,7 +3,7 @@
 import re
 import sys
 from enum import Enum, unique
-from typing import Dict, List, Set
+from typing import Dict, List, Optional, Set
 
 from reqstool_python_decorators.decorators.decorators import Requirements
 from ruamel.yaml import YAML
@@ -31,7 +31,7 @@ from reqstool.models.imports import GitImportData, ImportDataInterface, LocalImp
 from reqstool.models.requirements import (
     CATEGORIES,
     IMPLEMENTATION,
-    SIGNIFANCETYPES,
+    SIGNIFICANCETYPES,
     VARIANTS,
     MetaData,
     ReferenceData,
@@ -273,8 +273,8 @@ class RequirementsModelGenerator:
             for urn in data["filters"].keys():
                 urn_filter = data["filters"][urn]
 
-                req_urn_ids_imports: Set[str] = None  # NOSONAR
-                req_urn_ids_excludes: Set[str] = None  # NOSONAR
+                req_urn_ids_imports: Optional[Set[UrnId]] = None
+                req_urn_ids_excludes: Optional[Set[UrnId]] = None
                 custom_includes = None
                 custom_exclude = None
 
@@ -337,15 +337,13 @@ class RequirementsModelGenerator:
                         ]
                     )
 
-                # Check if rationale is defined, or set it to None
-                rationale = req["rationale"] if "rationale" in req else None
-                # Check if implementation is defined, or set it to True
-                implementation = req["implementation"] if "implementation" in req else IMPLEMENTATION.IN_CODE.value
+                rationale = req.get("rationale")
+                implementation = req.get("implementation", IMPLEMENTATION.IN_CODE.value)
                 urn_id = UrnId(urn=urn, id=req["id"])
                 req_data = RequirementData(
                     id=urn_id,
                     title=req["title"],
-                    significance=SIGNIFANCETYPES(req["significance"]),
+                    significance=SIGNIFICANCETYPES(req["significance"]),
                     description=req["description"],
                     rationale=rationale,
                     implementation=IMPLEMENTATION(implementation),

--- a/src/reqstool/model_generators/svcs_model_generator.py
+++ b/src/reqstool/model_generators/svcs_model_generator.py
@@ -1,7 +1,7 @@
 # Copyright © LFV
 
 import sys
-from typing import Dict, Set
+from typing import Dict, Optional, Set
 
 from ruamel.yaml import YAML
 
@@ -55,9 +55,9 @@ class SVCsModelGenerator:
                 id=urn_id,
                 requirement_ids=Utils.convert_ids_to_urn_id(ids=case["requirement_ids"], urn=self.urn),
                 title=case["title"],
-                description=case["description"] if "description" in case else None,
+                description=case.get("description"),
                 verification=VERIFICATIONTYPES(case["verification"]),
-                instructions=case["instructions"] if "instructions" in case else None,
+                instructions=case.get("instructions"),
                 revision=Utils.parse_version(version_str=case["revision"], urn_id=urn_id),
                 lifecycle=LifecycleData.from_dict(case.get("lifecycle")),
             )
@@ -76,8 +76,8 @@ class SVCsModelGenerator:
             for urn in data["filters"].keys():
                 urn_filter = data["filters"][urn]
 
-                svc_urn_ids_includes: Set[UrnId] = None  # NOSONAR
-                svc_urn_ids_excludes: Set[UrnId] = None  # NOSONAR
+                svc_urn_ids_includes: Optional[Set[UrnId]] = None
+                svc_urn_ids_excludes: Optional[Set[UrnId]] = None
                 custom_includes = None
                 custom_exclude = None
 

--- a/src/reqstool/models/requirements.py
+++ b/src/reqstool/models/requirements.py
@@ -28,7 +28,7 @@ class TYPES(Enum):
 
 
 @unique
-class SIGNIFANCETYPES(Enum):
+class SIGNIFICANCETYPES(Enum):
     SHALL = "shall"
     SHOULD = "should"
     MAY = "may"
@@ -67,7 +67,7 @@ class ReferenceData:
 class RequirementData:
     id: UrnId
     title: str
-    significance: SIGNIFANCETYPES
+    significance: SIGNIFICANCETYPES
     description: str
     rationale: str
     revision: Version

--- a/tests/unit/reqstool/expression_languages/test_requirements_el.py
+++ b/tests/unit/reqstool/expression_languages/test_requirements_el.py
@@ -5,7 +5,7 @@ from reqstool_python_decorators.decorators.decorators import SVCs
 
 from reqstool.common.dataclasses.urn_id import UrnId
 from reqstool.expression_languages.requirements_el import RequirementsELTransformer
-from reqstool.models.requirements import SIGNIFANCETYPES, RequirementData
+from reqstool.models.requirements import SIGNIFICANCETYPES, RequirementData
 
 
 @pytest.fixture
@@ -24,7 +24,7 @@ def requirement_data():
         return RequirementData(
             id=UrnId.instance(req_id),
             title="some title",
-            significance=SIGNIFANCETYPES("shall"),
+            significance=SIGNIFICANCETYPES("shall"),
             description="some description",
             rationale="some rationale",
             categories=["maintainability", "functional-suitability"],

--- a/tests/unit/reqstool/model_generators/test_filter_logic.py
+++ b/tests/unit/reqstool/model_generators/test_filter_logic.py
@@ -6,7 +6,7 @@ from reqstool.common.dataclasses.urn_id import UrnId
 from reqstool.filters.requirements_filters import RequirementFilter
 from reqstool.filters.svcs_filters import SVCFilter
 from reqstool.model_generators.indexed_dataset_filter_processor import _IndexedDatasetFilterProcessor
-from reqstool.models.requirements import IMPLEMENTATION, SIGNIFANCETYPES, RequirementData
+from reqstool.models.requirements import IMPLEMENTATION, SIGNIFICANCETYPES, RequirementData
 from reqstool.models.svcs import VERIFICATIONTYPES, SVCData
 
 # ---------------------------------------------------------------------------
@@ -24,7 +24,7 @@ def _req(urn_id: UrnId) -> RequirementData:
     return RequirementData(
         id=urn_id,
         title="t",
-        significance=SIGNIFANCETYPES.SHALL,
+        significance=SIGNIFICANCETYPES.SHALL,
         description="d",
         rationale="r",
         revision=Version("0.0.1"),

--- a/tests/unit/reqstool/model_generators/test_requirements_model_generator.py
+++ b/tests/unit/reqstool/model_generators/test_requirements_model_generator.py
@@ -6,7 +6,7 @@ from reqstool.common.dataclasses.urn_id import UrnId
 from reqstool.common.validator_error_holder import ValidationErrorHolder
 from reqstool.common.validators.semantic_validator import SemanticValidator
 from reqstool.model_generators.requirements_model_generator import RequirementsModelGenerator
-from reqstool.models.requirements import CATEGORIES, SIGNIFANCETYPES, VARIANTS
+from reqstool.models.requirements import CATEGORIES, SIGNIFICANCETYPES, VARIANTS
 
 REQUIREMENTS_YML_FILE = "requirements.yml"
 
@@ -103,7 +103,7 @@ def test_system_requirements_model_generator(resource_funcname_rootdir_w_path):
     # REQUIREMENTS
     assert model.requirements[UrnId(urn="sys-001", id="REQ_001")].id.id == "REQ_001"
     assert model.requirements[UrnId(urn="sys-001", id="REQ_001")].title == "Title REQ_001"
-    assert model.requirements[UrnId(urn="sys-001", id="REQ_001")].significance == SIGNIFANCETYPES.MAY
+    assert model.requirements[UrnId(urn="sys-001", id="REQ_001")].significance == SIGNIFICANCETYPES.MAY
     assert model.requirements[UrnId(urn="sys-001", id="REQ_001")].description == "Description REQ_001"
     assert model.requirements[UrnId(urn="sys-001", id="REQ_001")].rationale == "Rationale REQ_001"
     assert model.requirements[UrnId(urn="sys-001", id="REQ_001")].categories == [
@@ -158,7 +158,7 @@ def test_microservice_requirements_model_generator(resource_funcname_rootdir_w_p
     # REQUIREMENTS
     assert model.requirements[UrnId(urn="ms-001", id="REQ_001")].id.id == "REQ_001"
     assert model.requirements[UrnId(urn="ms-001", id="REQ_001")].title == "Title REQ_001"
-    assert model.requirements[UrnId(urn="ms-001", id="REQ_001")].significance == SIGNIFANCETYPES.SHALL
+    assert model.requirements[UrnId(urn="ms-001", id="REQ_001")].significance == SIGNIFICANCETYPES.SHALL
     assert model.requirements[UrnId(urn="ms-001", id="REQ_001")].description == "Description REQ_001"
     assert model.requirements[UrnId(urn="ms-001", id="REQ_001")].rationale == "Rationale REQ_001"
     assert model.requirements[UrnId(urn="ms-001", id="REQ_001")].categories == [CATEGORIES.FUNCTIONAL_SUITABILITY]
@@ -189,7 +189,7 @@ def test_external_requirements_model_generator(resource_funcname_rootdir_w_path)
     # REQUIREMENTS
     assert model.requirements[UrnId(urn="ext-001", id="REQ_001")].id.id == "REQ_001"
     assert model.requirements[UrnId(urn="ext-001", id="REQ_001")].title == "Title REQ_001"
-    assert model.requirements[UrnId(urn="ext-001", id="REQ_001")].significance == SIGNIFANCETYPES.MAY
+    assert model.requirements[UrnId(urn="ext-001", id="REQ_001")].significance == SIGNIFICANCETYPES.MAY
     assert model.requirements[UrnId(urn="ext-001", id="REQ_001")].description == "Description REQ_001"
     assert model.requirements[UrnId(urn="ext-001", id="REQ_001")].rationale == "Rationale REQ_001"
     assert model.requirements[UrnId(urn="ext-001", id="REQ_001")].categories == [
@@ -225,7 +225,7 @@ def test_rational_optional_model_generator(resource_funcname_rootdir_w_path):
     # REQUIREMENTS
     assert model.requirements[UrnId(urn="ext-001", id="REQ_001")].id.id == "REQ_001"
     assert model.requirements[UrnId(urn="ext-001", id="REQ_001")].title == "Title REQ_001"
-    assert model.requirements[UrnId(urn="ext-001", id="REQ_001")].significance == SIGNIFANCETYPES.MAY
+    assert model.requirements[UrnId(urn="ext-001", id="REQ_001")].significance == SIGNIFICANCETYPES.MAY
     assert model.requirements[UrnId(urn="ext-001", id="REQ_001")].description == "Description REQ_001"
     assert model.requirements[UrnId(urn="ext-001", id="REQ_001")].rationale is None
     assert model.requirements[UrnId(urn="ext-001", id="REQ_001")].categories == [


### PR DESCRIPTION
## Summary
- Fix typo: rename `SIGNIFANCETYPES` → `SIGNIFICANCETYPES` across 6 files (definition + all usages)
- Replace `if "key" in dict` / ternary patterns with `dict.get()` in `requirements_model_generator.py`, `svcs_model_generator.py`, and `mvrs_model_generator.py`
- Fix type annotations: use `Optional[LocationInterface]` and `Optional[Set[UrnId]]` instead of bare `None` assignments with incorrect type hints

## Test plan
- [x] All 202 unit tests pass (86% coverage)
- [x] flake8 clean
- [x] black format check passes
- [x] Regression smoke test: all 6 outputs identical to main (status/report × test_standard/test_basic/reqstool-demo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)