### PR TITLE
fix: fix check_release workflow to actually validate releases

### DIFF
--- a/.github/workflows/check_release.yml
+++ b/.github/workflows/check_release.yml
@@ -1,4 +1,4 @@
-name: Lint (black and flake8)
+name: Check Release
 on:
   workflow_call:
 
@@ -6,6 +6,16 @@ jobs:
   check-release:
     runs-on: ubuntu-latest
     steps:
-      - name: Check branch and tag
-        if: github.event_name == 'push' && !(github.ref == 'refs/heads/main' && startsWith(github.ref, 'refs/tags/v'))
-        run: exit 1
+      - name: Check tag format
+        run: |
+          if ! echo "${{ github.ref }}" | grep -qE '^refs/tags/[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "Tag must be a semver version like 1.2.3 (no v prefix)"
+            exit 1
+          fi
+      - name: Check branch
+        run: |
+          branch="${{ github.event.release.target_commitish }}"
+          if [[ "$branch" != "main" && "$branch" != hotfix/* && "$branch" != release/* ]]; then
+            echo "Release must target main, hotfix/*, or release/* branch (got: $branch)"
+            exit 1
+          fi


### PR DESCRIPTION
## Problem

`check_release.yml` was a no-op: the `if: github.event_name == 'push'` condition is always `false` when called via `workflow_call` from a `release` event. The check never ran.

## Changes

- Fixed workflow name
- Removed the broken no-op condition  
- Added tag format validation (bare semver, e.g. `1.2.3`, no `v` prefix)
- Added branch validation (allows `main`, `hotfix/*`, `release/*`)