### PR TITLE
fix: count 1 per requirement with implementation instead of summing annotations

### DIFF
--- a/src/reqstool/commands/status/statistics_container.py
+++ b/src/reqstool/commands/status/statistics_container.py
@@ -61,7 +61,8 @@ class TotalStatisticsItem:
         self.nr_of_total_requirements += 1
         self.nr_of_missing_automated_tests += combined_req_test_item.automated_tests_stats.nr_of_missing_automated_tests
         self.nr_of_missing_manual_tests += combined_req_test_item.mvrs_stats.nr_of_missing_manual_tests
-        self.nr_of_reqs_with_implementation += combined_req_test_item.nr_of_implementations
+        if combined_req_test_item.nr_of_implementations > 0:
+            self.nr_of_reqs_with_implementation += 1
 
         # Some requirements could be completed without any implementation
         if completed and combined_req_test_item.implementation == IMPLEMENTATION.NOT_APPLICABLE:

--- a/src/reqstool/commands/status/status.py
+++ b/src/reqstool/commands/status/status.py
@@ -46,9 +46,8 @@ def _build_table(
     if implementation == IMPLEMENTATION.NOT_APPLICABLE:
         row.extend(["N/A"])
     else:
-        row.extend(
-            [Fore.GREEN + "Implemented" + Style.RESET_ALL if impls > 0 else Fore.RED + "Missing" + Style.RESET_ALL]
-        )
+        color = Fore.GREEN if impls > 0 else Fore.RED
+        row.extend([f"{color}{impls}{Style.RESET_ALL}"])
     _extend_row(tests, row, kind="automated")
     _extend_row(mvrs, row, kind="manual")
     return row
@@ -58,10 +57,15 @@ def _get_row_with_totals(stats_container: StatisticsContainer) -> List[str]:
     ts = stats_container._total_statistics
     total_automatic = ts.nr_of_passed_automatic_tests + ts.nr_of_failed_automatic_tests
     total_manual = ts.nr_of_passed_manual_tests + ts.nr_of_failed_manual_tests
+    total_implementations = sum(
+        stats.nr_of_implementations
+        for stats in stats_container._requirement_statistics.values()
+        if stats.implementation != IMPLEMENTATION.NOT_APPLICABLE
+    )
     return [
         "Total",
         "",
-        "",
+        str(total_implementations),
         _format_cell(total_automatic),
         _format_cell(ts.nr_of_passed_automatic_tests, Fore.GREEN),
         _format_cell(ts.nr_of_failed_automatic_tests, Fore.RED),

--- a/tests/unit/reqstool/commands/status/test_status_presentation.py
+++ b/tests/unit/reqstool/commands/status/test_status_presentation.py
@@ -145,8 +145,8 @@ def test_build_table_not_applicable_shows_na():
     assert row[2] == "N/A"
 
 
-def test_build_table_in_code_with_impls_shows_implemented():
-    """IN_CODE with impls > 0 shows 'Implemented' in green."""
+def test_build_table_in_code_with_impls_shows_count():
+    """IN_CODE with impls > 0 shows numeric count in green."""
     row = _build_table(
         req_id="REQ_001",
         urn="ms-001",
@@ -156,12 +156,12 @@ def test_build_table_in_code_with_impls_shows_implemented():
         completed=True,
         implementation=IMPLEMENTATION.IN_CODE,
     )
-    assert "Implemented" in row[2]
+    assert "2" in row[2]
     assert Fore.GREEN in row[2]
 
 
-def test_build_table_in_code_no_impls_shows_missing():
-    """IN_CODE with impls == 0 shows 'Missing' in red."""
+def test_build_table_in_code_no_impls_shows_zero():
+    """IN_CODE with impls == 0 shows 0 in red."""
     row = _build_table(
         req_id="REQ_001",
         urn="ms-001",
@@ -171,7 +171,7 @@ def test_build_table_in_code_no_impls_shows_missing():
         completed=False,
         implementation=IMPLEMENTATION.IN_CODE,
     )
-    assert "Missing" in row[2]
+    assert "0" in row[2]
     assert Fore.RED in row[2]
 
 


### PR DESCRIPTION
## Summary

- Fixed `TotalStatisticsItem.update()` to count 1 per requirement that has any implementation, instead of summing all annotation counts — this caused the "Implemented" count to exceed `nr_of_total_requirements` (e.g. 181%)
- Changed the Implementation column in the status table from text ("Implemented"/"Missing") to numeric annotation count per requirement
- Added implementation total to the Total row in the status table

Reported by David on PR #306.

## Test plan

- [x] All 202 unit tests pass
- [x] Smoke tested with `test_standard/baseline/ms-001` — "Implemented" = 5/6 (83.33%), no inflation
- [x] Smoke tested with `test_basic/baseline/ms-101` — "Implemented" = 2/4 (50.00%), no inflation
- [ ] Smoke test with `reqstool-demo` to verify real-world output

🤖 Generated with [Claude Code](https://claude.com/claude-code)