### PR TITLE
fix(ci): poll PyPI JSON API for availability check

### DIFF
--- a/.github/workflows/release_prod.yml
+++ b/.github/workflows/release_prod.yml
@@ -73,7 +73,7 @@ jobs:
           VERSION="${{ steps.meta.outputs.version }}"
           echo "Waiting for reqstool==${VERSION} to become available on PyPI..."
           for i in $(seq 1 90); do
-            if pip install --dry-run --no-cache-dir "reqstool==${VERSION}" &>/dev/null; then
+            if curl -fsSL -o /dev/null "https://pypi.org/pypi/reqstool/${VERSION}/json"; then
               echo "reqstool==${VERSION} is available on PyPI"
               exit 0
             fi


### PR DESCRIPTION
## Summary

- Replace `pip install --dry-run --no-cache-dir` with `curl` against the PyPI JSON API (`/pypi/{name}/{version}/json`) in the \"Wait for PyPI availability\" step of `release_prod.yml`.

## Root cause

PR #341 intended this switch but landed with `--no-cache-dir` only. That was insufficient: pip resolves through the Simple Index, which is served via Fastly and can return stale `/simple/reqstool/` pages to a given POP for minutes after upload. `--no-cache-dir` disables pip's on-disk cache but does not bypass the upstream HTTP/CDN cache.

Observed in run [24624666126](https://github.com/reqstool/reqstool-client/actions/runs/24624666126/job/72001573402) — release of 0.9.0 polled 90× over 15 minutes and never saw the package, even though \`GET https://pypi.org/pypi/reqstool/0.9.0/json\` returns 200 right now.

The JSON API is the canonical, cache-friendly endpoint for \"does this version exist\".

## Test plan

- [ ] Next release: \`publish-image-to-ghcr\` → \"Wait for PyPI availability\" transitions to \"is available on PyPI\" within a few attempts
- [ ] If needed, re-dispatch the 0.9.0 release via \`workflow_dispatch\` (existing \`skip-existing: true\` on the publish action handles the already-uploaded case)