### PR TITLE
ci: extract GHCR image publish into manually-dispatchable workflow

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,75 @@
+name: Publish image to GHCR
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "reqstool version on PyPI to build the image for"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "reqstool version on PyPI to build the image for (e.g. 0.9.0)"
+        required: true
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: "${{ github.repository_owner }}/reqstool"
+
+jobs:
+  publish-image-to-ghcr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ inputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
+            type=semver,pattern={{major}},value=${{ inputs.version }},enable=${{ !startsWith(inputs.version, '0.') }}
+            type=sha
+            type=raw,value=latest
+
+      - name: Wait for PyPI availability
+        run: |
+          VERSION="${{ inputs.version }}"
+          echo "Waiting for reqstool==${VERSION} to become available on PyPI..."
+          for i in $(seq 1 90); do
+            if curl -fsSL -o /dev/null "https://pypi.org/pypi/reqstool/${VERSION}/json"; then
+              echo "reqstool==${VERSION} is available on PyPI"
+              exit 0
+            fi
+            echo "Attempt ${i}/90 - not yet available, waiting 10s..."
+            sleep 10
+          done
+          echo "::error::reqstool==${VERSION} not found on PyPI after 15 minutes"
+          exit 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push container image to GHCR
+        uses: docker/build-push-action@v7
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: REQSTOOL_VERSION=${{ inputs.version }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -57,17 +57,17 @@ jobs:
           exit 1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push container image to GHCR
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release_prod.yml
+++ b/.github/workflows/release_prod.yml
@@ -43,60 +43,13 @@ jobs:
           skip-existing: true
 
   publish-image-to-ghcr:
-    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    needs:
+      - publish-to-pypi
     permissions:
       contents: read
       packages: write
       id-token: write
-    needs:
-      - publish-to-pypi
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          # List of Docker images to use as base name for tags
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          # Generate Docker tags based on the following events/attributes
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-            type=sha
-
-      - name: Wait for PyPI availability
-        run: |
-          VERSION="${{ steps.meta.outputs.version }}"
-          echo "Waiting for reqstool==${VERSION} to become available on PyPI..."
-          for i in $(seq 1 90); do
-            if curl -fsSL -o /dev/null "https://pypi.org/pypi/reqstool/${VERSION}/json"; then
-              echo "reqstool==${VERSION} is available on PyPI"
-              exit 0
-            fi
-            echo "Attempt ${i}/90 - not yet available, waiting 10s..."
-            sleep 10
-          done
-          echo "::error::reqstool==${VERSION} not found on PyPI after 15 minutes"
-          exit 1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push container image to GHCR
-        uses: docker/build-push-action@v7
-        with:
-          push: true # Always push the image on release or manual dispatch
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: REQSTOOL_VERSION=${{ steps.meta.outputs.version }}
+    uses: ./.github/workflows/publish-image.yml
+    with:
+      version: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Summary

- New reusable workflow `.github/workflows/publish-image.yml` that publishes the reqstool image to GHCR for an explicit PyPI version.
- Supports both `workflow_call` (used from `release_prod.yml`) and `workflow_dispatch` (manual republish of any past version).
- `release_prod.yml` now calls this workflow on `release` events, passing `github.event.release.tag_name` as the version.
- Tag computation switched from `github.ref` parsing to `inputs.version`. The existing `!startsWith(github.ref, 'refs/tags/v0.')` guard for the bare-major tag never matched (this repo uses unprefixed tags like `0.9.0`); replaced with `!startsWith(inputs.version, '0.')`, matching the original intent.

## Motivation

0.9.0's image publish failed during the release run (stale Fastly cache in `pip install --dry-run`, fixed for future runs in #348). Neither re-run nor `workflow_dispatch` on the `0.9.0` tag can recover it:

- Re-run reuses prior run state / cached misses.
- `workflow_dispatch` on a tag uses the workflow file at that tag (still broken).
- `workflow_dispatch` on `main` after #348 produces wrong semver tags because `github.ref` is a branch.

A standalone input-driven workflow sidesteps all of these.

## Test plan

- [x] After merge, manually dispatch `Publish image to GHCR` with `version: 0.9.0` and verify `ghcr.io/reqstool/reqstool:0.9.0`, `:0.9`, `:0`, `:latest`, `:sha-<current>` are pushed
- [x] Verify the built image runs: `docker run --rm ghcr.io/reqstool/reqstool:0.9.0 reqstool --version`
- [x] Next real release: confirm `release_prod.yml` → reusable `publish-image.yml` chain still runs end-to-end