### PR TITLE
fix: make git import path field optional, defaulting to repo root

### DIFF
--- a/src/reqstool/locations/git_location.py
+++ b/src/reqstool/locations/git_location.py
@@ -15,7 +15,7 @@ class GitLocation(LocationInterface):
     url: str
     branch: str
     env_token: Optional[str] = None
-    path: str
+    path: str = ""
 
     def _make_available_on_localdisk(self, dst_path: str) -> str:
         api_token = os.getenv(self.env_token)

--- a/src/reqstool/model_generators/requirements_model_generator.py
+++ b/src/reqstool/model_generators/requirements_model_generator.py
@@ -228,7 +228,7 @@ class RequirementsModelGenerator:
                         env_token=git.env_token,
                         url=git.url,
                         branch=git.branch,
-                        path=git.path,
+                        path=git.path or "",
                     ),
                 )
 

--- a/src/reqstool/models/generated/requirements_schema.py
+++ b/src/reqstool/models/generated/requirements_schema.py
@@ -63,7 +63,7 @@ class Git(BaseModel):
     """
     URL to repository host
     """
-    path: str
+    path: str | None = None
     """
     Path to a directory with reqstool files (requirements.yml (required), software_verification_cases.yml and/or manual_verification_results.yml)
     """

--- a/src/reqstool/resources/schemas/v1/requirements.schema.json
+++ b/src/reqstool/resources/schemas/v1/requirements.schema.json
@@ -121,8 +121,7 @@
             },
             "required": [
                 "branch",
-                "url",
-                "path"
+                "url"
             ]
         },
         "maven": {

--- a/tests/unit/reqstool/locations/test_git_location.py
+++ b/tests/unit/reqstool/locations/test_git_location.py
@@ -29,3 +29,20 @@ def test_git_location(resource_funcname_rootdir_w_path):
     assert git_location.url == "https://git.example.com/repo.git"
     assert git_location.branch == "test"
     assert git_location.path == PATH
+
+
+def test_git_location_path_defaults_to_empty_string():
+    git_location = GitLocation(
+        url="https://git.example.com/repo.git",
+        branch="main",
+    )
+    assert git_location.path == ""
+
+
+def test_git_location_explicit_path_still_works():
+    git_location = GitLocation(
+        url="https://git.example.com/repo.git",
+        branch="main",
+        path="docs/reqstool",
+    )
+    assert git_location.path == "docs/reqstool"


### PR DESCRIPTION
Closes #354

## Summary

- Removes `path` from the `required` array in the git location JSON schema (now only `branch` and `url` are required)
- Defaults `GitLocation.path` to `""` so `os.path.join` resolves to the cloned repo root when no subdirectory is specified
- Updates the generated Pydantic model (`requirements_schema.py`) accordingly
- Adds `path or ""` guard in `requirements_model_generator.py` when constructing `GitLocation` from parsed YAML
- Adds two new unit tests: one verifying the default, one verifying an explicit path still works

## Test plan

- [x] `hatch run dev:pytest tests/unit/reqstool/locations/test_git_location.py -v` — all 3 tests pass
- [x] `hatch run dev:pytest tests/unit/ -q` — full unit suite (559 tests) passes
- [x] `hatch run dev:flake8` — no lint errors
- [x] CI passes