### PR TITLE
fix: guard env_token None check in git, maven, and pypi locations

### DIFF
--- a/src/reqstool/locations/git_location.py
+++ b/src/reqstool/locations/git_location.py
@@ -18,7 +18,7 @@ class GitLocation(LocationInterface):
     path: str = ""
 
     def _make_available_on_localdisk(self, dst_path: str) -> str:
-        api_token = os.getenv(self.env_token)
+        api_token = os.getenv(self.env_token) if self.env_token else None
 
         if self.branch:
             repo = clone_repository(

--- a/src/reqstool/locations/maven_location.py
+++ b/src/reqstool/locations/maven_location.py
@@ -22,7 +22,7 @@ class MavenLocation(LocationInterface):
     env_token: Optional[str] = None
 
     def _make_available_on_localdisk(self, dst_path: str):
-        token = os.getenv(self.env_token)
+        token = os.getenv(self.env_token) if self.env_token else None
 
         # assume OAuth Bearer, see: https://georgearisty.dev/posts/oauth2-token-bearer-usage/
         downloader = Downloader(base=self.url, token=token)

--- a/src/reqstool/locations/pypi_location.py
+++ b/src/reqstool/locations/pypi_location.py
@@ -27,7 +27,7 @@ class PypiLocation(LocationInterface):
         Download the PyPI package and extract it to the local disk.
         """
         # Retrieve token from environment variable
-        token = os.getenv(self.env_token)
+        token = os.getenv(self.env_token) if self.env_token else None
 
         if token:
             logging.debug("Using OAuth Bearer token for authentication")

--- a/tests/unit/reqstool/locations/test_git_location.py
+++ b/tests/unit/reqstool/locations/test_git_location.py
@@ -1,5 +1,7 @@
 # Copyright © LFV
 
+from unittest.mock import MagicMock, patch
+
 from reqstool.locations.git_location import GitLocation
 
 
@@ -46,3 +48,22 @@ def test_git_location_explicit_path_still_works():
         path="docs/reqstool",
     )
     assert git_location.path == "docs/reqstool"
+
+
+def test_git_location_env_token_defaults_to_none():
+    git_location = GitLocation(
+        url="https://git.example.com/repo.git",
+        branch="main",
+        path="/tmp/somepath",
+    )
+    assert git_location.env_token is None
+
+
+def test_git_location_make_available_no_env_token(tmp_path):
+    git_location = GitLocation(url="https://git.example.com/repo.git", branch="main", path="")
+    mock_repo = MagicMock()
+    mock_repo.workdir = str(tmp_path)
+    with patch("reqstool.locations.git_location.clone_repository", return_value=mock_repo) as mock_clone:
+        result = git_location._make_available_on_localdisk(str(tmp_path))
+    mock_clone.assert_called_once()
+    assert result == str(tmp_path)

--- a/tests/unit/reqstool/locations/test_maven_location.py
+++ b/tests/unit/reqstool/locations/test_maven_location.py
@@ -1,0 +1,23 @@
+# Copyright © LFV
+
+from unittest.mock import MagicMock, patch
+
+from reqstool.locations.maven_location import MavenLocation
+
+
+def test_maven_location_env_token_defaults_to_none():
+    loc = MavenLocation(group_id="com.example", artifact_id="my-lib", version="1.0.0")
+    assert loc.env_token is None
+
+
+def test_maven_location_make_available_no_env_token(tmp_path):
+    loc = MavenLocation(group_id="com.example", artifact_id="my-lib", version="1.0.0")
+    mock_downloader = MagicMock()
+    mock_downloader.download.return_value = True
+    extracted = str(tmp_path / "extracted")
+    with (
+        patch("reqstool.locations.maven_location.Downloader", return_value=mock_downloader),
+        patch("reqstool.locations.maven_location.Utils.extract_zip", return_value=extracted),
+    ):
+        result = loc._make_available_on_localdisk(str(tmp_path))
+    assert result == extracted

--- a/tests/unit/reqstool/locations/test_pypi_location.py
+++ b/tests/unit/reqstool/locations/test_pypi_location.py
@@ -1,0 +1,22 @@
+# Copyright © LFV
+
+from unittest.mock import patch
+
+from reqstool.locations.pypi_location import PypiLocation
+
+
+def test_pypi_location_env_token_defaults_to_none():
+    loc = PypiLocation(package="my-package", version="1.0.0")
+    assert loc.env_token is None
+
+
+def test_pypi_location_make_available_no_env_token(tmp_path):
+    loc = PypiLocation(package="my-package", version="1.0.0")
+    extracted = str(tmp_path / "extracted")
+    with (
+        patch.object(PypiLocation, "get_package_url", return_value="https://example.com/pkg.tar.gz"),
+        patch("reqstool.locations.pypi_location.Utils.download_file", return_value=str(tmp_path / "pkg.tar.gz")),
+        patch("reqstool.locations.pypi_location.Utils.extract_targz", return_value=extracted),
+    ):
+        result = loc._make_available_on_localdisk(str(tmp_path))
+    assert result == extracted


### PR DESCRIPTION
Closes #355

## Summary

- Adds `if self.env_token else None` guard before calling `os.getenv()` in `git_location.py`, `maven_location.py`, and `pypi_location.py`
- Calling `os.getenv(None)` raises `TypeError: str expected, not NoneType`; this fix treats a missing `env_token` as unauthenticated access
- Adds unit tests for all three location types: one verifying the field defaults to `None`, one verifying `_make_available_on_localdisk` does not crash when `env_token` is omitted

## Test plan

- [x] `hatch run dev:pytest tests/unit/reqstool/locations/ -v` — all 14 tests pass
- [x] `hatch run dev:pytest tests/unit/ -q` — full unit suite (563 tests) passes
- [x] `hatch run dev:flake8` — no lint errors
- [x] CI passes