### PR TITLE
fix: lsp documentSymbol parser picks items from wrong YAML section

### DIFF
--- a/src/reqstool/lsp/features/document_symbols.py
+++ b/src/reqstool/lsp/features/document_symbols.py
@@ -15,6 +15,13 @@ REQSTOOL_YAML_FILES = {
     "manual_verification_results.yml",
 }
 
+# Top-level YAML key that holds the list of items in each file type
+_COLLECTION_KEYS = {
+    "requirements.yml": "requirements",
+    "software_verification_cases.yml": "cases",
+    "manual_verification_results.yml": "results",
+}
+
 
 class _YamlItem:
     """A parsed YAML list item with its fields and line range."""
@@ -51,7 +58,8 @@ def handle_document_symbols(
     if basename not in REQSTOOL_YAML_FILES:
         return []
 
-    items = _parse_yaml_items(text)
+    collection_key = _COLLECTION_KEYS[basename]
+    items = _parse_yaml_items(text, collection_key)
     if not items:
         return []
 
@@ -73,6 +81,9 @@ def _symbols_for_requirements(
     symbols: list[types.DocumentSymbol] = []
     for item in items:
         req_id = item.fields.get("id", "")
+        if not req_id:
+            continue
+
         title = item.fields.get("title", "")
         significance = item.fields.get("significance", "")
 
@@ -115,6 +126,9 @@ def _symbols_for_svcs(
     symbols: list[types.DocumentSymbol] = []
     for item in items:
         svc_id = item.fields.get("id", "")
+        if not svc_id:
+            continue
+
         title = item.fields.get("title", "")
         verification = item.fields.get("verification", "")
 
@@ -170,6 +184,9 @@ def _symbols_for_mvrs(
     symbols: list[types.DocumentSymbol] = []
     for item in items:
         svc_id = item.fields.get("id", "")
+        if not svc_id:
+            continue
+
         passed = item.fields.get("passed", "")
 
         result = "pass" if passed.lower() == "true" else "fail" if passed else ""
@@ -188,20 +205,39 @@ def _symbols_for_mvrs(
     return symbols
 
 
-def _parse_yaml_items(text: str) -> list[_YamlItem]:
-    """Parse YAML text to extract list items under the main collection key.
+def _parse_yaml_items(text: str, collection_key: str) -> list[_YamlItem]:
+    """Parse YAML text to extract list items under the named top-level collection key.
 
-    Looks for the first top-level array (e.g., requirements:, svcs:, results:)
-    and extracts each `- key: value` block.
+    Only items directly under `collection_key:` are returned; list items in other
+    top-level sections (e.g. `imports:`, `filters:`) are ignored.
     """
     lines = text.splitlines()
     items: list[_YamlItem] = []
     current_item: _YamlItem | None = None
     list_indent = -1
+    in_collection = False
 
     for i, line in enumerate(lines):
         stripped = line.rstrip()
         if not stripped or stripped.startswith("#"):
+            continue
+
+        # Detect top-level keys: no leading whitespace, `word:` pattern
+        if not line[0].isspace():
+            top_level = re.match(r'^(\w[\w-]*):', line)
+            if top_level:
+                new_key = top_level.group(1)
+                if in_collection and new_key != collection_key:
+                    # Leaving the target section — flush any in-progress item
+                    if current_item is not None:
+                        current_item.end_line = i - 1
+                        items.append(current_item)
+                        current_item = None
+                    list_indent = -1
+                in_collection = (new_key == collection_key)
+                continue
+
+        if not in_collection:
             continue
 
         current_item, list_indent = _process_yaml_line(line, i, items, current_item, list_indent)

--- a/tests/unit/reqstool/lsp/test_document_symbols.py
+++ b/tests/unit/reqstool/lsp/test_document_symbols.py
@@ -21,7 +21,7 @@ def test_parse_yaml_items_requirements():
         "    title: Second requirement\n"
         "    significance: should\n"
     )
-    items = _parse_yaml_items(text)
+    items = _parse_yaml_items(text, "requirements")
     assert len(items) == 2
     assert items[0].fields["id"] == "REQ_001"
     assert items[0].fields["title"] == "First requirement"
@@ -30,8 +30,8 @@ def test_parse_yaml_items_requirements():
 
 
 def test_parse_yaml_items_svcs():
-    text = "svcs:\n" "  - id: SVC_001\n" "    title: Test case\n" "    verification: automated-test\n"
-    items = _parse_yaml_items(text)
+    text = "cases:\n" "  - id: SVC_001\n" "    title: Test case\n" "    verification: automated-test\n"
+    items = _parse_yaml_items(text, "cases")
     assert len(items) == 1
     assert items[0].fields["id"] == "SVC_001"
     assert items[0].fields["verification"] == "automated-test"
@@ -39,7 +39,7 @@ def test_parse_yaml_items_svcs():
 
 def test_parse_yaml_items_empty():
     text = "metadata:\n  urn: test\n"
-    items = _parse_yaml_items(text)
+    items = _parse_yaml_items(text, "requirements")
     assert len(items) == 0
 
 
@@ -52,9 +52,75 @@ def test_parse_yaml_items_with_metadata():
         "  - id: REQ_001\n"
         "    title: Test\n"
     )
-    items = _parse_yaml_items(text)
+    items = _parse_yaml_items(text, "requirements")
     assert len(items) == 1
     assert items[0].fields["id"] == "REQ_001"
+
+
+def test_parse_yaml_items_ignores_other_sections():
+    """Items in sections other than collection_key must not be returned."""
+    text = (
+        "metadata:\n"
+        "  urn: test\n"
+        "implementations:\n"
+        "  local:\n"
+        "    - path: ../other/reqstool\n"
+        "    - path: ../another/reqstool\n"
+        "requirements:\n"
+        "  - id: REQ_001\n"
+        "    title: Real requirement\n"
+        "    significance: shall\n"
+    )
+    items = _parse_yaml_items(text, "requirements")
+    assert len(items) == 1
+    assert items[0].fields["id"] == "REQ_001"
+
+
+def test_parse_yaml_items_filter_only_file_returns_empty():
+    """A filter-only file with no requirements section produces no items."""
+    text = (
+        "metadata:\n"
+        "  urn: atunko-core\n"
+        "  variant: microservice\n"
+        "\n"
+        "implementations:\n"
+        "  local:\n"
+        "    - path: ../../../docs/reqstool\n"
+        "\n"
+        "filters:\n"
+        "  atunko:\n"
+        "    custom:\n"
+        "      includes: ids == /CORE_.*/\n"
+    )
+    items = _parse_yaml_items(text, "requirements")
+    assert len(items) == 0
+
+
+def test_parse_yaml_items_imports_section_does_not_pollute():
+    """The implementations/imports list items must not appear as requirement items."""
+    text = (
+        "implementations:\n"
+        "  local:\n"
+        "    - path: ../../atunko-core/docs/reqstool\n"
+        "    - path: ../../atunko-cli/docs/reqstool\n"
+        "    - path: ../../atunko-tui/docs/reqstool\n"
+        "    - path: ../../atunko-web/docs/reqstool\n"
+        "\n"
+        "requirements:\n"
+        "  - id: WEB_0001\n"
+        "    title: Web UI Launch\n"
+        "    significance: shall\n"
+        "  - id: WEB_0001.1\n"
+        "    title: Web UI — Recipe TreeGrid\n"
+        "    significance: shall\n"
+    )
+    items = _parse_yaml_items(text, "requirements")
+    assert len(items) == 2
+    assert items[0].fields["id"] == "WEB_0001"
+    assert items[1].fields["id"] == "WEB_0001.1"
+    for item in items:
+        assert item.fields["id"] != ""
+        assert "path" not in item.fields
 
 
 # -- Document symbols --
@@ -84,7 +150,7 @@ def test_document_symbols_requirements():
 
 
 def test_document_symbols_svcs():
-    text = "svcs:\n" "  - id: SVC_001\n" "    title: Login test\n" "    verification: automated-test\n"
+    text = "cases:\n" "  - id: SVC_001\n" "    title: Login test\n" "    verification: automated-test\n"
     symbols = handle_document_symbols(
         uri="file:///workspace/software_verification_cases.yml",
         text=text,
@@ -129,6 +195,56 @@ def test_document_symbols_empty():
     assert symbols == []
 
 
+def test_document_symbols_filter_only_file_is_empty():
+    """A requirements.yml with only metadata/imports/filters produces no symbols."""
+    text = (
+        "metadata:\n"
+        "  urn: atunko-core\n"
+        "  variant: microservice\n"
+        "\n"
+        "implementations:\n"
+        "  local:\n"
+        "    - path: ../../../docs/reqstool\n"
+        "\n"
+        "filters:\n"
+        "  atunko:\n"
+        "    custom:\n"
+        "      includes: ids == /CORE_.*/\n"
+    )
+    symbols = handle_document_symbols(
+        uri="file:///workspace/requirements.yml",
+        text=text,
+        project=None,
+    )
+    assert symbols == []
+
+
+def test_document_symbols_no_empty_names():
+    """No symbol produced by handle_document_symbols should have an empty name."""
+    text = (
+        "implementations:\n"
+        "  local:\n"
+        "    - path: ../../atunko-core/docs/reqstool\n"
+        "    - path: ../../atunko-web/docs/reqstool\n"
+        "\n"
+        "requirements:\n"
+        "  - id: WEB_0001\n"
+        "    title: Web UI Launch\n"
+        "    significance: shall\n"
+        "  - id: WEB_0001.1\n"
+        "    title: Web UI — Recipe TreeGrid\n"
+        "    significance: shall\n"
+    )
+    symbols = handle_document_symbols(
+        uri="file:///workspace/requirements.yml",
+        text=text,
+        project=None,
+    )
+    assert len(symbols) == 2
+    for sym in symbols:
+        assert sym.name, f"Symbol at line {sym.range.start.line} has an empty name"
+
+
 def test_document_symbols_with_project(local_testdata_resources_rootdir_w_path):
     """Test that symbols include children when project is loaded."""
     import os
@@ -149,10 +265,11 @@ def test_document_symbols_with_project(local_testdata_resources_rootdir_w_path):
                 project=state,
             )
             assert len(symbols) > 0
-            # Symbols should be DocumentSymbol instances
+            # Symbols should be DocumentSymbol instances with non-empty names
             for sym in symbols:
                 assert isinstance(sym, types.DocumentSymbol)
                 assert sym.kind == types.SymbolKind.Key
+                assert sym.name, f"Symbol at line {sym.range.start.line} has an empty name"
     finally:
         state.close()
 
@@ -166,7 +283,7 @@ def test_parse_yaml_items_line_ranges():
         "  - id: REQ_002\n"
         "    title: Second\n"
     )
-    items = _parse_yaml_items(text)
+    items = _parse_yaml_items(text, "requirements")
     assert len(items) == 2
     assert items[0].start_line == 1
     assert items[0].id_line == 1


### PR DESCRIPTION
Closes #359

## Summary

- `_parse_yaml_items` now accepts a `collection_key` parameter and tracks the active top-level YAML key, so only items under the correct section (`requirements`, `cases`, `results`) are parsed
- Each `_symbols_for_*` builder skips any item whose `id` field is empty (secondary guard)
- Added `_COLLECTION_KEYS` mapping from filename to collection key

## Root cause

The parser set `list_indent` from the first `- key: value` line in the file regardless of which top-level section it was inside. In a filter-only `requirements.yml` (with `implementations.local` but no `requirements:` block), `- path: ...` entries were treated as requirements, producing `DocumentSymbol` objects with `name: ""` that VS Code rejects.

## Tests

- Updated all existing `_parse_yaml_items()` call sites to pass `collection_key`
- Fixed `test_document_symbols_svcs` to use the correct `cases:` collection key
- Added `test_parse_yaml_items_ignores_other_sections`
- Added `test_parse_yaml_items_filter_only_file_returns_empty`
- Added `test_parse_yaml_items_imports_section_does_not_pollute`
- Added `test_document_symbols_filter_only_file_is_empty`
- Added `test_document_symbols_no_empty_names`