### PR TITLE
fix(lsp): source documentSymbol data from project state

### DIFF
--- a/src/reqstool/common/project_session.py
+++ b/src/reqstool/common/project_session.py
@@ -8,6 +8,7 @@ from reqstool.common.validators.semantic_validator import SemanticValidator
 from reqstool.common.validator_error_holder import ValidationErrorHolder
 from reqstool.locations.location import LocationInterface
 from reqstool.model_generators.combined_raw_datasets_generator import CombinedRawDatasetsGenerator
+from reqstool.model_generators.parsing_config import ParsingConfig
 from reqstool.storage.database import RequirementsDatabase
 from reqstool.storage.database_filter_processor import DatabaseFilterProcessor
 from reqstool.storage.requirements_repository import RequirementsRepository
@@ -23,8 +24,9 @@ class ProjectSession:
     (MCP, LSP) that need persistent read access after a one-time build.
     """
 
-    def __init__(self, location: LocationInterface):
+    def __init__(self, location: LocationInterface, parsing_config: ParsingConfig = ParsingConfig()):
         self._location = location
+        self._parsing_config = parsing_config
         self._db: RequirementsDatabase | None = None
         self._repo: RequirementsRepository | None = None
         self._urn_source_paths: dict[str, dict[str, str]] = {}
@@ -59,6 +61,7 @@ class ProjectSession:
                 initial_location=self._location,
                 semantic_validator=semantic_validator,
                 database=db,
+                parsing_config=self._parsing_config,
             )
             crd = crdg.combined_raw_datasets
 

--- a/src/reqstool/lsp/features/document_symbols.py
+++ b/src/reqstool/lsp/features/document_symbols.py
@@ -2,44 +2,20 @@
 
 
 import os
-import re
+from urllib.parse import unquote, urlparse
 
 from lsprotocol import types
 
 from reqstool.lsp.project_state import ProjectState
+from reqstool.models.mvrs import MVRData
+from reqstool.models.requirements import RequirementData
+from reqstool.models.svcs import SVCData
 
-# YAML files that the LSP provides document symbols for
 REQSTOOL_YAML_FILES = {
     "requirements.yml",
     "software_verification_cases.yml",
     "manual_verification_results.yml",
 }
-
-
-class _YamlItem:
-    """A parsed YAML list item with its fields and line range."""
-
-    __slots__ = ("fields", "start_line", "end_line", "id_line")
-
-    def __init__(self, start_line: int):
-        self.fields: dict[str, str] = {}
-        self.start_line = start_line
-        self.end_line = start_line
-        self.id_line = start_line
-
-    @property
-    def range(self) -> types.Range:
-        return types.Range(
-            start=types.Position(line=self.start_line, character=0),
-            end=types.Position(line=self.end_line, character=0),
-        )
-
-    @property
-    def selection_range(self) -> types.Range:
-        return types.Range(
-            start=types.Position(line=self.id_line, character=0),
-            end=types.Position(line=self.id_line, character=0),
-        )
 
 
 def handle_document_symbols(
@@ -50,196 +26,144 @@ def handle_document_symbols(
     basename = os.path.basename(uri)
     if basename not in REQSTOOL_YAML_FILES:
         return []
-
-    items = _parse_yaml_items(text)
-    if not items:
+    if project is None or not project.ready:
         return []
 
-    if basename == "requirements.yml":
-        return _symbols_for_requirements(items, text, project)
-    elif basename == "software_verification_cases.yml":
-        return _symbols_for_svcs(items, text, project)
-    elif basename == "manual_verification_results.yml":
-        return _symbols_for_mvrs(items, text, project)
+    file_path = _uri_to_path(uri)
+    line_count = max(1, len(text.splitlines()))
 
+    if basename == "requirements.yml":
+        return _symbols_for_requirements(project.get_requirements_for_yaml(file_path), project, line_count)
+    if basename == "software_verification_cases.yml":
+        return _symbols_for_svcs(project.get_svcs_for_yaml(file_path), project, line_count)
+    if basename == "manual_verification_results.yml":
+        return _symbols_for_mvrs(project.get_mvrs_for_yaml(file_path), line_count)
     return []
 
 
 def _symbols_for_requirements(
-    items: list[_YamlItem],
-    text: str,
-    project: ProjectState | None,
+    reqs: list[RequirementData],
+    project: ProjectState,
+    line_count: int,
 ) -> list[types.DocumentSymbol]:
+    sorted_reqs = sorted(reqs, key=_source_line_or_inf)
     symbols: list[types.DocumentSymbol] = []
-    for item in items:
-        req_id = item.fields.get("id", "")
-        title = item.fields.get("title", "")
-        significance = item.fields.get("significance", "")
-
-        name = f"{req_id} — {title}" if title else req_id
-        detail = significance
-
-        children: list[types.DocumentSymbol] = []
-        if project is not None and project.ready and req_id:
-            svcs = project.get_svcs_for_req(req_id)
-            for svc in svcs:
-                children.append(
-                    types.DocumentSymbol(
-                        name=f"→ {svc.id.id} — {svc.title}",
-                        kind=types.SymbolKind.Key,
-                        range=item.range,
-                        selection_range=item.range,
-                        detail=svc.verification.value if hasattr(svc, "verification") else "",
-                    )
+    for idx, req in enumerate(sorted_reqs):
+        start = req.source_line if req.source_line is not None else 0
+        end = _end_line(sorted_reqs, idx, line_count)
+        name = f"{req.id.id} — {req.title}" if req.title else req.id.id
+        children = []
+        for svc in project.get_svcs_for_req(req.id.id):
+            children.append(
+                types.DocumentSymbol(
+                    name=f"→ {svc.id.id} — {svc.title}",
+                    kind=types.SymbolKind.Key,
+                    range=_range(start, end),
+                    selection_range=_range(start, start),
+                    detail=svc.verification.value,
                 )
-
+            )
         symbols.append(
             types.DocumentSymbol(
                 name=name,
                 kind=types.SymbolKind.Key,
-                range=item.range,
-                selection_range=item.selection_range,
-                detail=detail,
+                range=_range(start, end),
+                selection_range=_range(start, start),
+                detail=req.significance.value,
                 children=children if children else None,
             )
         )
-
     return symbols
 
 
 def _symbols_for_svcs(
-    items: list[_YamlItem],
-    text: str,
-    project: ProjectState | None,
+    svcs: list[SVCData],
+    project: ProjectState,
+    line_count: int,
 ) -> list[types.DocumentSymbol]:
+    sorted_svcs = sorted(svcs, key=_source_line_or_inf)
     symbols: list[types.DocumentSymbol] = []
-    for item in items:
-        svc_id = item.fields.get("id", "")
-        title = item.fields.get("title", "")
-        verification = item.fields.get("verification", "")
-
-        name = f"{svc_id} — {title}" if title else svc_id
-        detail = verification
-
-        children: list[types.DocumentSymbol] = []
-        if project is not None and project.ready and svc_id:
-            svc = project.get_svc(svc_id)
-            if svc and svc.requirement_ids:
-                for req_ref in svc.requirement_ids:
-                    req_id_str = req_ref.id if hasattr(req_ref, "id") else str(req_ref)
-                    children.append(
-                        types.DocumentSymbol(
-                            name=f"← {req_id_str}",
-                            kind=types.SymbolKind.Key,
-                            range=item.range,
-                            selection_range=item.range,
-                        )
-                    )
-
-            mvrs = project.get_mvrs_for_svc(svc_id)
-            for mvr in mvrs:
-                result = "pass" if mvr.passed else "fail"
-                children.append(
-                    types.DocumentSymbol(
-                        name=f"→ MVR: {result}",
-                        kind=types.SymbolKind.Key,
-                        range=item.range,
-                        selection_range=item.range,
-                    )
+    for idx, svc in enumerate(sorted_svcs):
+        start = svc.source_line if svc.source_line is not None else 0
+        end = _end_line(sorted_svcs, idx, line_count)
+        name = f"{svc.id.id} — {svc.title}" if svc.title else svc.id.id
+        children = []
+        for req_urn_id in svc.requirement_ids:
+            children.append(
+                types.DocumentSymbol(
+                    name=f"← {req_urn_id.id}",
+                    kind=types.SymbolKind.Key,
+                    range=_range(start, end),
+                    selection_range=_range(start, start),
                 )
-
+            )
+        for mvr in project.get_mvrs_for_svc(svc.id.id):
+            result = "pass" if mvr.passed else "fail"
+            children.append(
+                types.DocumentSymbol(
+                    name=f"→ MVR: {result}",
+                    kind=types.SymbolKind.Key,
+                    range=_range(start, end),
+                    selection_range=_range(start, start),
+                )
+            )
         symbols.append(
             types.DocumentSymbol(
                 name=name,
                 kind=types.SymbolKind.Key,
-                range=item.range,
-                selection_range=item.selection_range,
-                detail=detail,
+                range=_range(start, end),
+                selection_range=_range(start, start),
+                detail=svc.verification.value,
                 children=children if children else None,
             )
         )
-
     return symbols
 
 
 def _symbols_for_mvrs(
-    items: list[_YamlItem],
-    text: str,
-    project: ProjectState | None,
+    mvrs: list[MVRData],
+    line_count: int,
 ) -> list[types.DocumentSymbol]:
+    sorted_mvrs = sorted(mvrs, key=_source_line_or_inf)
     symbols: list[types.DocumentSymbol] = []
-    for item in items:
-        svc_id = item.fields.get("id", "")
-        passed = item.fields.get("passed", "")
-
-        result = "pass" if passed.lower() == "true" else "fail" if passed else ""
-        name = f"{svc_id} — {result}" if result else svc_id
-
+    for idx, mvr in enumerate(sorted_mvrs):
+        start = mvr.source_line if mvr.source_line is not None else 0
+        end = _end_line(sorted_mvrs, idx, line_count)
+        result = "pass" if mvr.passed else "fail"
+        name = f"{mvr.id.id} — {result}"
         symbols.append(
             types.DocumentSymbol(
                 name=name,
                 kind=types.SymbolKind.Key,
-                range=item.range,
-                selection_range=item.selection_range,
+                range=_range(start, end),
+                selection_range=_range(start, start),
                 detail="",
             )
         )
-
     return symbols
 
 
-def _parse_yaml_items(text: str) -> list[_YamlItem]:
-    """Parse YAML text to extract list items under the main collection key.
-
-    Looks for the first top-level array (e.g., requirements:, svcs:, results:)
-    and extracts each `- key: value` block.
-    """
-    lines = text.splitlines()
-    items: list[_YamlItem] = []
-    current_item: _YamlItem | None = None
-    list_indent = -1
-
-    for i, line in enumerate(lines):
-        stripped = line.rstrip()
-        if not stripped or stripped.startswith("#"):
-            continue
-
-        current_item, list_indent = _process_yaml_line(line, i, items, current_item, list_indent)
-
-    if current_item is not None:
-        current_item.end_line = len(lines) - 1
-        items.append(current_item)
-
-    return items
+def _source_line_or_inf(item) -> float:
+    return item.source_line if item.source_line is not None else float("inf")
 
 
-def _process_yaml_line(line, i, items, current_item, list_indent):
-    """Process a single YAML line, returning updated (current_item, list_indent)."""
-    dash_match = re.match(r"^(\s*)-\s+(\w[\w-]*)\s*:\s*(.*)", line)
-    if dash_match:
-        indent = len(dash_match.group(1))
-        if list_indent < 0:
-            list_indent = indent
-        if indent == list_indent:
-            if current_item is not None:
-                current_item.end_line = i - 1
-                items.append(current_item)
-            current_item = _YamlItem(start_line=i)
-            current_item.fields[dash_match.group(2)] = dash_match.group(3).strip()
-            if dash_match.group(2) == "id":
-                current_item.id_line = i
-            return current_item, list_indent
+def _end_line(items, idx: int, line_count: int) -> int:
+    if idx + 1 < len(items):
+        next_line = items[idx + 1].source_line
+        if next_line is not None:
+            return max(0, next_line - 1)
+    return max(0, line_count - 1)
 
-    if current_item is not None and list_indent >= 0:
-        field_match = re.match(r"^(\s+)(\w[\w-]*)\s*:\s*(.*)", line)
-        if field_match and len(field_match.group(1)) > list_indent:
-            current_item.fields[field_match.group(2)] = field_match.group(3).strip()
-            if field_match.group(2) == "id":
-                current_item.id_line = i
-            current_item.end_line = i
-        elif field_match:
-            current_item.end_line = i - 1
-            items.append(current_item)
-            return None, -1
 
-    return current_item, list_indent
+def _range(start_line: int, end_line: int) -> types.Range:
+    return types.Range(
+        start=types.Position(line=start_line, character=0),
+        end=types.Position(line=end_line, character=0),
+    )
+
+
+def _uri_to_path(uri: str) -> str:
+    parsed = urlparse(uri)
+    if parsed.scheme == "file":
+        return unquote(parsed.path)
+    return uri

--- a/src/reqstool/lsp/project_state.py
+++ b/src/reqstool/lsp/project_state.py
@@ -2,10 +2,12 @@
 
 
 import logging
+import os
 
 from reqstool.common.models.urn_id import UrnId
 from reqstool.common.project_session import ProjectSession
 from reqstool.locations.local_location import LocalLocation
+from reqstool.model_generators.parsing_config import ParsingConfig
 from reqstool.models.annotations import AnnotationData
 from reqstool.models.mvrs import MVRData
 from reqstool.models.requirements import RequirementData
@@ -17,7 +19,10 @@ logger = logging.getLogger(__name__)
 
 class ProjectState(ProjectSession):
     def __init__(self, reqstool_path: str):
-        super().__init__(LocalLocation(path=reqstool_path))
+        super().__init__(
+            LocalLocation(path=reqstool_path),
+            parsing_config=ParsingConfig(include_line_numbers=True),
+        )
         self._reqstool_path = reqstool_path
 
     @property
@@ -116,3 +121,35 @@ class ProjectState(ProjectSession):
         if urn_paths is None:
             return None
         return urn_paths.get(file_type)
+
+    def _urn_for_yaml_path(self, file_path: str, file_type: str) -> str | None:
+        norm_target = os.path.normpath(file_path)
+        for urn, paths in self._urn_source_paths.items():
+            stored = paths.get(file_type)
+            if stored is not None and os.path.normpath(stored) == norm_target:
+                return urn
+        return None
+
+    def get_requirements_for_yaml(self, file_path: str) -> list[RequirementData]:
+        if not self._ready or self._repo is None:
+            return []
+        urn = self._urn_for_yaml_path(file_path, "requirements")
+        if urn is None:
+            return []
+        return [r for r in self._repo.get_all_requirements().values() if r.id.urn == urn]
+
+    def get_svcs_for_yaml(self, file_path: str) -> list[SVCData]:
+        if not self._ready or self._repo is None:
+            return []
+        urn = self._urn_for_yaml_path(file_path, "svcs")
+        if urn is None:
+            return []
+        return [s for s in self._repo.get_all_svcs().values() if s.id.urn == urn]
+
+    def get_mvrs_for_yaml(self, file_path: str) -> list[MVRData]:
+        if not self._ready or self._repo is None:
+            return []
+        urn = self._urn_for_yaml_path(file_path, "mvrs")
+        if urn is None:
+            return []
+        return [m for m in self._repo.get_all_mvrs().values() if m.id.urn == urn]

--- a/src/reqstool/model_generators/combined_raw_datasets_generator.py
+++ b/src/reqstool/model_generators/combined_raw_datasets_generator.py
@@ -15,6 +15,7 @@ from reqstool.locations.local_location import LocalLocation
 from reqstool.locations.location import LocationInterface
 from reqstool.model_generators.annotations_model_generator import AnnotationsModelGenerator
 from reqstool.model_generators.mvrs_model_generator import MVRsModelGenerator
+from reqstool.model_generators.parsing_config import ParsingConfig
 from reqstool.model_generators.requirements_model_generator import RequirementsModelGenerator
 from reqstool.model_generators.svcs_model_generator import SVCsModelGenerator
 from reqstool.model_generators.testdata_model_generator import TestDataModelGenerator
@@ -37,6 +38,7 @@ class CombinedRawDatasetsGenerator:
         semantic_validator: SemanticValidator,
         database: Optional[RequirementsDatabase] = None,
         tmpdir_manager: Optional[TempDirectoryManager] = None,
+        parsing_config: ParsingConfig = ParsingConfig(),
     ):
         self.__level: int = 0
         self.__initial_location_handler: LocationResolver = LocationResolver(
@@ -47,6 +49,7 @@ class CombinedRawDatasetsGenerator:
         self._parsing_graph: Dict[str, List[Tuple[str, str]]] = defaultdict(list)
         self._database = database
         self._tmpdir_manager = tmpdir_manager if tmpdir_manager is not None else TempDirectoryManager()
+        self._parsing_config = parsing_config
         self.combined_raw_datasets = self.__generate()
 
     def __generate(self) -> CombinedRawDataset:
@@ -264,6 +267,7 @@ class CombinedRawDatasetsGenerator:
             filename=requirements_indata.requirements_indata_paths.requirements_yml.path,
             prefix_with_urn=False,
             semantic_validator=self.semantic_validator,
+            parsing_config=self._parsing_config,
         )
 
         if self.__level > 0:
@@ -347,6 +351,7 @@ class CombinedRawDatasetsGenerator:
                 uri=requirements_indata.requirements_indata_paths.svcs_yml.path,
                 semantic_validator=self.semantic_validator,
                 urn=current_urn,
+                parsing_config=self._parsing_config,
             ).model
 
         # handle automated test results
@@ -365,7 +370,9 @@ class CombinedRawDatasetsGenerator:
 
         if requirements_indata.requirements_indata_paths.mvrs_yml.exists:
             mvrs_data = MVRsModelGenerator(
-                uri=requirements_indata.requirements_indata_paths.mvrs_yml.path, urn=current_urn
+                uri=requirements_indata.requirements_indata_paths.mvrs_yml.path,
+                urn=current_urn,
+                parsing_config=self._parsing_config,
             ).model
 
         # handle annotations

--- a/src/reqstool/model_generators/mvrs_model_generator.py
+++ b/src/reqstool/model_generators/mvrs_model_generator.py
@@ -9,14 +9,16 @@ from reqstool.commands.exit_codes import EXIT_CODE_SYNTAX_VALIDATION_ERROR
 from reqstool.common.models.urn_id import UrnId
 from reqstool.common.utils import Utils
 from reqstool.common.validators.syntax_validator import JsonSchemaTypes, SyntaxValidator
+from reqstool.model_generators.parsing_config import ParsingConfig
 from reqstool.models.generated.manual_verification_results_schema import Model as MVRsPydanticModel
 from reqstool.models.mvrs import MVRData, MVRsData
 
 
 class MVRsModelGenerator:
-    def __init__(self, uri: str, urn: str):
+    def __init__(self, uri: str, urn: str, parsing_config: ParsingConfig = ParsingConfig()):
         self.uri = uri
         self.urn = urn
+        self.parsing_config = parsing_config
         self.model = self.__generate(uri)
 
     def __generate(self, uri: str) -> MVRsData:
@@ -32,11 +34,32 @@ class MVRsModelGenerator:
             sys.exit(EXIT_CODE_SYNTAX_VALIDATION_ERROR)
 
         validated = MVRsPydanticModel.model_validate(data)
-        results = self.__parse_mvrs(validated)
+
+        source_lines = self.__capture_source_lines(response.text) if self.parsing_config.include_line_numbers else {}
+
+        results = self.__parse_mvrs(validated, source_lines)
 
         return MVRsData(results=results)
 
-    def __parse_mvrs(self, validated: MVRsPydanticModel) -> Dict[UrnId, MVRData]:
+    @staticmethod
+    def __capture_source_lines(text: str) -> Dict[str, int]:
+        rt_yaml = YAML(typ="rt")
+        rt_data = rt_yaml.load(text)
+        result: Dict[str, int] = {}
+        if rt_data is None or "results" not in rt_data:
+            return result
+        results = rt_data["results"]
+        if results is None:
+            return result
+        for idx, item in enumerate(results):
+            if not hasattr(results, "lc"):
+                break
+            line = results.lc.item(idx)[0]
+            if isinstance(item, dict) and "id" in item:
+                result[str(item["id"])] = line
+        return result
+
+    def __parse_mvrs(self, validated: MVRsPydanticModel, source_lines: Dict[str, int]) -> Dict[UrnId, MVRData]:
         r_result = {}
 
         for result in validated.results:
@@ -46,6 +69,7 @@ class MVRsModelGenerator:
                 svc_ids=Utils.convert_ids_to_urn_id(ids=result.svc_ids, urn=self.urn),
                 comment=result.comment,
                 passed=result.pass_,
+                source_line=source_lines.get(result.id),
             )
 
             r_result[mvr.id] = mvr

--- a/src/reqstool/model_generators/parsing_config.py
+++ b/src/reqstool/model_generators/parsing_config.py
@@ -1,0 +1,9 @@
+# Copyright © LFV
+
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ParsingConfig:
+    include_line_numbers: bool = False

--- a/src/reqstool/model_generators/requirements_model_generator.py
+++ b/src/reqstool/model_generators/requirements_model_generator.py
@@ -21,6 +21,7 @@ from reqstool.locations.local_location import LocalLocation
 from reqstool.locations.location import LocationInterface
 from reqstool.locations.maven_location import MavenLocation
 from reqstool.locations.pypi_location import PypiLocation
+from reqstool.model_generators.parsing_config import ParsingConfig
 from reqstool.models.generated.requirements_schema import Model as RequirementsPydanticModel
 from reqstool.models.implementations import (
     GitImplData,
@@ -56,11 +57,13 @@ class RequirementsModelGenerator:
         semantic_validator: SemanticValidator,
         filename: str,
         prefix_with_urn: bool = False,
+        parsing_config: ParsingConfig = ParsingConfig(),
     ):
         self.parent = parent
         self.filename = filename
         self.prefix_with_urn = prefix_with_urn
         self.semantic_validator = semantic_validator
+        self.parsing_config = parsing_config
         self.requirements_data = self.__generate(filename)
 
     @staticmethod
@@ -100,11 +103,13 @@ class RequirementsModelGenerator:
         r_requirements: Dict[str, RequirementData] = {}
         r_filters: Dict[str, RequirementFilter] = {}
 
+        source_lines = self.__capture_source_lines(response.text) if self.parsing_config.include_line_numbers else {}
+
         self.prefix_with_urn = False
         r_imports = self.__parse_imports(validated)
         r_filters = self.__parse_requirement_filters(data=data)
         r_implementations = self.__parse_implementations(validated)
-        r_requirements = self.__parse_requirements(validated, data=data)
+        r_requirements = self.__parse_requirements(validated, data=data, source_lines=source_lines)
 
         return RequirementsData(
             metadata=r_metadata,
@@ -242,8 +247,26 @@ class RequirementsModelGenerator:
             validate_fn=self.semantic_validator._validate_req_imports_filter_has_excludes_xor_includes,
         )
 
+    @staticmethod
+    def __capture_source_lines(text: str) -> Dict[str, int]:
+        rt_yaml = YAML(typ="rt")
+        rt_data = rt_yaml.load(text)
+        result: Dict[str, int] = {}
+        if rt_data is None or "requirements" not in rt_data:
+            return result
+        reqs = rt_data["requirements"]
+        if reqs is None:
+            return result
+        for idx, item in enumerate(reqs):
+            if not hasattr(reqs, "lc"):
+                break
+            line = reqs.lc.item(idx)[0]
+            if isinstance(item, dict) and "id" in item:
+                result[str(item["id"])] = line
+        return result
+
     @Requirements("REQ_004", "REQ_036")
-    def __parse_requirements(self, model, data):  # NOSONAR
+    def __parse_requirements(self, model, data, source_lines: Dict[str, int]):  # NOSONAR
         r_reqs = {}
 
         self.semantic_validator._validate_no_duplicate_requirement_ids(data=data)
@@ -281,6 +304,7 @@ class RequirementsModelGenerator:
                     lifecycle=LifecycleData.from_dict(
                         {"state": req.lifecycle.state.value, "reason": req.lifecycle.reason} if req.lifecycle else None
                     ),
+                    source_line=source_lines.get(req.id),
                 )
 
                 if req_data.id not in r_reqs:

--- a/src/reqstool/model_generators/svcs_model_generator.py
+++ b/src/reqstool/model_generators/svcs_model_generator.py
@@ -13,15 +13,23 @@ from reqstool.common.utils import Utils
 from reqstool.common.validators.semantic_validator import SemanticValidator
 from reqstool.common.validators.syntax_validator import JsonSchemaTypes, SyntaxValidator
 from reqstool.filters.svcs_filters import SVCFilter
+from reqstool.model_generators.parsing_config import ParsingConfig
 from reqstool.models.generated.software_verification_cases_schema import Model as SVCsPydanticModel
 from reqstool.models.svcs import VERIFICATIONTYPES, SVCData, SVCsData
 
 
 class SVCsModelGenerator:
-    def __init__(self, uri: str, semantic_validator: SemanticValidator, urn: str):
+    def __init__(
+        self,
+        uri: str,
+        semantic_validator: SemanticValidator,
+        urn: str,
+        parsing_config: ParsingConfig = ParsingConfig(),
+    ):
         self.uri = uri
         self.semantic_validator = semantic_validator
         self.urn = urn
+        self.parsing_config = parsing_config
         self.model = self.__generate(uri)
 
     def __generate(self, uri: str) -> SVCsData:
@@ -41,12 +49,32 @@ class SVCsModelGenerator:
 
         validated = SVCsPydanticModel.model_validate(data)
 
-        cases = self.__parse_svcs(validated)
+        source_lines = self.__capture_source_lines(response.text) if self.parsing_config.include_line_numbers else {}
+
+        cases = self.__parse_svcs(validated, source_lines)
         filters = self.__parse_svc_filters(data)
 
         return SVCsData(cases=cases, filters=filters)
 
-    def __parse_svcs(self, validated: SVCsPydanticModel) -> dict[UrnId, SVCData]:
+    @staticmethod
+    def __capture_source_lines(text: str) -> Dict[str, int]:
+        rt_yaml = YAML(typ="rt")
+        rt_data = rt_yaml.load(text)
+        result: Dict[str, int] = {}
+        if rt_data is None or "cases" not in rt_data:
+            return result
+        cases = rt_data["cases"]
+        if cases is None:
+            return result
+        for idx, item in enumerate(cases):
+            if not hasattr(cases, "lc"):
+                break
+            line = cases.lc.item(idx)[0]
+            if isinstance(item, dict) and "id" in item:
+                result[str(item["id"])] = line
+        return result
+
+    def __parse_svcs(self, validated: SVCsPydanticModel, source_lines: Dict[str, int]) -> dict[UrnId, SVCData]:
         r_result = {}
 
         for case in validated.cases:
@@ -65,6 +93,7 @@ class SVCsModelGenerator:
                 lifecycle=LifecycleData.from_dict(
                     {"state": case.lifecycle.state.value, "reason": case.lifecycle.reason} if case.lifecycle else None
                 ),
+                source_line=source_lines.get(case.id),
             )
 
             if svc.id not in r_result:

--- a/src/reqstool/models/mvrs.py
+++ b/src/reqstool/models/mvrs.py
@@ -14,6 +14,7 @@ class MVRData(BaseModel):
     comment: Optional[str] = None
     passed: bool
     svc_ids: List[UrnId] = Field(default_factory=list)
+    source_line: Optional[int] = None
 
 
 class MVRsData(BaseModel):

--- a/src/reqstool/models/requirements.py
+++ b/src/reqstool/models/requirements.py
@@ -95,6 +95,7 @@ class RequirementData(BaseModel):
     implementation: IMPLEMENTATION = IMPLEMENTATION.IN_CODE
     categories: List[CATEGORIES] = Field(default_factory=list)
     references: Optional[List[ReferenceData]] = Field(default_factory=list)
+    source_line: Optional[int] = None
 
 
 class MetaData(BaseModel):

--- a/src/reqstool/models/svcs.py
+++ b/src/reqstool/models/svcs.py
@@ -31,6 +31,7 @@ class SVCData(BaseModel):
     revision: VersionField
     lifecycle: LifecycleData = Field(default_factory=lambda: LifecycleData(state=LIFECYCLESTATE.EFFECTIVE, reason=None))
     requirement_ids: List[UrnId] = Field(default_factory=list)
+    source_line: Optional[int] = None
 
 
 class SVCsData(BaseModel):

--- a/src/reqstool/storage/database.py
+++ b/src/reqstool/storage/database.py
@@ -48,8 +48,8 @@ class RequirementsDatabase:
     def insert_requirement(self, urn: str, req: RequirementData) -> None:
         self._conn.execute(
             "INSERT INTO requirements (urn, id, title, significance, lifecycle_state, lifecycle_reason,"
-            " implementation, description, rationale, revision)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            " implementation, description, rationale, revision, source_line)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 urn,
                 req.id.id,
@@ -61,6 +61,7 @@ class RequirementsDatabase:
                 req.description,
                 req.rationale,
                 str(req.revision),
+                req.source_line,
             ),
         )
 
@@ -82,8 +83,8 @@ class RequirementsDatabase:
     def insert_svc(self, urn: str, svc: SVCData) -> None:
         self._conn.execute(
             "INSERT INTO svcs (urn, id, title, verification_type, lifecycle_state, lifecycle_reason,"
-            " description, instructions, revision)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            " description, instructions, revision, source_line)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 urn,
                 svc.id.id,
@@ -94,6 +95,7 @@ class RequirementsDatabase:
                 svc.description,
                 svc.instructions,
                 str(svc.revision),
+                svc.source_line,
             ),
         )
 
@@ -108,8 +110,8 @@ class RequirementsDatabase:
 
     def insert_mvr(self, urn: str, mvr: MVRData) -> None:
         self._conn.execute(
-            "INSERT INTO mvrs (urn, id, passed, comment) VALUES (?, ?, ?, ?)",
-            (urn, mvr.id.id, int(mvr.passed), mvr.comment),
+            "INSERT INTO mvrs (urn, id, passed, comment, source_line) VALUES (?, ?, ?, ?, ?)",
+            (urn, mvr.id.id, int(mvr.passed), mvr.comment, mvr.source_line),
         )
 
         for svc_urn_id in mvr.svc_ids:

--- a/src/reqstool/storage/pipeline.py
+++ b/src/reqstool/storage/pipeline.py
@@ -9,6 +9,7 @@ from reqstool.common.validators.lifecycle_validator import LifecycleValidator
 from reqstool.common.validators.semantic_validator import SemanticValidator
 from reqstool.locations.location import LocationInterface
 from reqstool.model_generators.combined_raw_datasets_generator import CombinedRawDatasetsGenerator
+from reqstool.model_generators.parsing_config import ParsingConfig
 from reqstool.models.raw_datasets import CombinedRawDataset
 from reqstool.storage.database import RequirementsDatabase
 from reqstool.storage.database_filter_processor import DatabaseFilterProcessor
@@ -21,6 +22,7 @@ def build_database(
     semantic_validator: SemanticValidator,
     filter_data: bool = True,
     tmpdir_manager: TempDirectoryManager = None,
+    parsing_config: ParsingConfig = ParsingConfig(),
 ) -> Generator[tuple[RequirementsDatabase, CombinedRawDataset], None, None]:
     _owns_tmpdir = tmpdir_manager is None
     if _owns_tmpdir:
@@ -32,6 +34,7 @@ def build_database(
             semantic_validator=semantic_validator,
             database=db,
             tmpdir_manager=tmpdir_manager,
+            parsing_config=parsing_config,
         )
         crd = crdg.combined_raw_datasets
 

--- a/src/reqstool/storage/requirements_repository.py
+++ b/src/reqstool/storage/requirements_repository.py
@@ -259,6 +259,7 @@ class RequirementsRepository:
             implementation=IMPLEMENTATION(row["implementation"]),
             categories=categories,
             references=references if references else [],
+            source_line=row["source_line"],
         )
 
     def _row_to_svc_data(self, row) -> SVCData:
@@ -285,6 +286,7 @@ class RequirementsRepository:
             revision=Version(row["revision"]),
             lifecycle=lifecycle,
             requirement_ids=requirement_ids,
+            source_line=row["source_line"],
         )
 
     def _row_to_mvr_data(self, row) -> MVRData:
@@ -302,4 +304,5 @@ class RequirementsRepository:
             comment=row["comment"],
             passed=bool(row["passed"]),
             svc_ids=svc_ids,
+            source_line=row["source_line"],
         )

--- a/src/reqstool/storage/schema.py
+++ b/src/reqstool/storage/schema.py
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS requirements (
     description TEXT NOT NULL,
     rationale TEXT,
     revision TEXT NOT NULL,
+    source_line INTEGER,
     PRIMARY KEY (urn, id)
 );
 
@@ -51,6 +52,7 @@ CREATE TABLE IF NOT EXISTS svcs (
     description TEXT,
     instructions TEXT,
     revision TEXT NOT NULL,
+    source_line INTEGER,
     PRIMARY KEY (urn, id)
 );
 
@@ -69,6 +71,7 @@ CREATE TABLE IF NOT EXISTS mvrs (
     id TEXT NOT NULL,
     passed INTEGER NOT NULL,
     comment TEXT,
+    source_line INTEGER,
     PRIMARY KEY (urn, id)
 );
 

--- a/tests/unit/reqstool/lsp/test_document_symbols.py
+++ b/tests/unit/reqstool/lsp/test_document_symbols.py
@@ -1,173 +1,128 @@
 # Copyright © LFV
 
+import os
+import textwrap
+
+import pytest
 from lsprotocol import types
 
-from reqstool.lsp.features.document_symbols import (
-    handle_document_symbols,
-    _parse_yaml_items,
-)
+from reqstool.lsp.features.document_symbols import handle_document_symbols
+from reqstool.lsp.project_state import ProjectState
 
 
-# -- YAML item parsing --
-
-
-def test_parse_yaml_items_requirements():
-    text = (
-        "requirements:\n"
-        "  - id: REQ_001\n"
-        "    title: First requirement\n"
-        "    significance: shall\n"
-        "  - id: REQ_002\n"
-        "    title: Second requirement\n"
-        "    significance: should\n"
-    )
-    items = _parse_yaml_items(text)
-    assert len(items) == 2
-    assert items[0].fields["id"] == "REQ_001"
-    assert items[0].fields["title"] == "First requirement"
-    assert items[0].fields["significance"] == "shall"
-    assert items[1].fields["id"] == "REQ_002"
-
-
-def test_parse_yaml_items_svcs():
-    text = "svcs:\n" "  - id: SVC_001\n" "    title: Test case\n" "    verification: automated-test\n"
-    items = _parse_yaml_items(text)
-    assert len(items) == 1
-    assert items[0].fields["id"] == "SVC_001"
-    assert items[0].fields["verification"] == "automated-test"
-
-
-def test_parse_yaml_items_empty():
-    text = "metadata:\n  urn: test\n"
-    items = _parse_yaml_items(text)
-    assert len(items) == 0
-
-
-def test_parse_yaml_items_with_metadata():
-    text = (
-        "metadata:\n"
-        "  urn: test\n"
-        "  variant: microservice\n"
-        "requirements:\n"
-        "  - id: REQ_001\n"
-        "    title: Test\n"
-    )
-    items = _parse_yaml_items(text)
-    assert len(items) == 1
-    assert items[0].fields["id"] == "REQ_001"
-
-
-# -- Document symbols --
-
-
-def test_document_symbols_requirements():
-    text = (
-        "requirements:\n"
-        "  - id: REQ_001\n"
-        "    title: First requirement\n"
-        "    significance: shall\n"
-        "  - id: REQ_002\n"
-        "    title: Second requirement\n"
-        "    significance: should\n"
-    )
-    symbols = handle_document_symbols(
-        uri="file:///workspace/requirements.yml",
-        text=text,
-        project=None,
-    )
-    assert len(symbols) == 2
-    assert "REQ_001" in symbols[0].name
-    assert "First requirement" in symbols[0].name
-    assert symbols[0].detail == "shall"
-    assert "REQ_002" in symbols[1].name
-    assert symbols[1].detail == "should"
-
-
-def test_document_symbols_svcs():
-    text = "svcs:\n" "  - id: SVC_001\n" "    title: Login test\n" "    verification: automated-test\n"
-    symbols = handle_document_symbols(
-        uri="file:///workspace/software_verification_cases.yml",
-        text=text,
-        project=None,
-    )
-    assert len(symbols) == 1
-    assert "SVC_001" in symbols[0].name
-    assert symbols[0].detail == "automated-test"
-
-
-def test_document_symbols_mvrs():
-    text = "results:\n" "  - id: SVC_001\n" "    passed: true\n" "  - id: SVC_002\n" "    passed: false\n"
-    symbols = handle_document_symbols(
-        uri="file:///workspace/manual_verification_results.yml",
-        text=text,
-        project=None,
-    )
-    assert len(symbols) == 2
-    assert "SVC_001" in symbols[0].name
-    assert "pass" in symbols[0].name
-    assert "SVC_002" in symbols[1].name
-    assert "fail" in symbols[1].name
-
-
-def test_document_symbols_non_reqstool_file():
-    text = "key: value\n"
-    symbols = handle_document_symbols(
-        uri="file:///workspace/other.yml",
-        text=text,
-        project=None,
-    )
-    assert symbols == []
-
-
-def test_document_symbols_empty():
-    text = ""
-    symbols = handle_document_symbols(
-        uri="file:///workspace/requirements.yml",
-        text=text,
-        project=None,
-    )
-    assert symbols == []
-
-
-def test_document_symbols_with_project(local_testdata_resources_rootdir_w_path):
-    """Test that symbols include children when project is loaded."""
-    import os
-
-    from reqstool.lsp.project_state import ProjectState
-
+@pytest.fixture
+def ms001_project(local_testdata_resources_rootdir_w_path):
     path = local_testdata_resources_rootdir_w_path("test_standard/baseline/ms-001")
     state = ProjectState(reqstool_path=path)
+    state.build()
+    yield path, state
+    state.close()
+
+
+def test_non_reqstool_file_returns_empty():
+    symbols = handle_document_symbols(uri="file:///workspace/other.yml", text="key: value\n", project=None)
+    assert symbols == []
+
+
+def test_no_project_returns_empty():
+    symbols = handle_document_symbols(
+        uri="file:///workspace/requirements.yml",
+        text="requirements:\n  - id: REQ_001\n",
+        project=None,
+    )
+    assert symbols == []
+
+
+def test_requirements_symbols_have_titles_and_significance(ms001_project):
+    path, state = ms001_project
+    req_file = os.path.join(path, "requirements.yml")
+    with open(req_file) as f:
+        text = f.read()
+
+    symbols = handle_document_symbols(uri="file://" + req_file, text=text, project=state)
+
+    assert len(symbols) == 2
+    for sym in symbols:
+        assert isinstance(sym, types.DocumentSymbol)
+        assert sym.kind == types.SymbolKind.Key
+        assert sym.name  # never empty
+    assert "REQ_010" in symbols[0].name
+    assert "Title REQ_010" in symbols[0].name
+    assert symbols[0].detail == "should"
+    assert "REQ_020" in symbols[1].name
+    assert symbols[1].detail == "shall"
+
+
+def test_requirements_symbol_line_numbers_match_yaml(ms001_project):
+    path, state = ms001_project
+    req_file = os.path.join(path, "requirements.yml")
+    with open(req_file) as f:
+        text = f.read()
+
+    symbols = handle_document_symbols(uri="file://" + req_file, text=text, project=state)
+
+    # REQ_010 is on line 15 (1-based) in the fixture → 0-based line 14
+    assert symbols[0].selection_range.start.line == 14
+    # REQ_020 is on line 22 → 0-based line 21
+    assert symbols[1].selection_range.start.line == 21
+
+
+def test_filter_only_requirements_yml_returns_empty(tmp_path):
+    """Regression for #359: a requirements.yml with only metadata/implementations/filters
+    must not produce ghost symbols with empty names."""
+    yml = textwrap.dedent(
+        """\
+        metadata:
+          urn: filter-only
+          variant: microservice
+          title: Filter only
+        implementations:
+          local:
+            - path: ../target
+        filters:
+          some-other-urn:
+            custom:
+              includes: ids == /CORE_.*/
+        """
+    )
+    req_file = tmp_path / "requirements.yml"
+    req_file.write_text(yml)
+
+    state = ProjectState(reqstool_path=str(tmp_path))
+    state.build()
     try:
-        state.build()
-        req_file = os.path.join(path, "requirements.yml")
-        if os.path.isfile(req_file):
-            with open(req_file) as f:
-                text = f.read()
-            symbols = handle_document_symbols(
-                uri="file://" + req_file,
-                text=text,
-                project=state,
-            )
-            assert len(symbols) > 0
-            # Symbols should be DocumentSymbol instances
-            for sym in symbols:
-                assert isinstance(sym, types.DocumentSymbol)
-                assert sym.kind == types.SymbolKind.Key
+        symbols = handle_document_symbols(uri="file://" + str(req_file), text=yml, project=state)
+        # Either ProjectState fails to build (no implementation target) or it builds but the file
+        # has no `requirements:` section — either way the outline must be empty, never empty-named.
+        assert symbols == [] or all(sym.name for sym in symbols)
     finally:
         state.close()
 
 
-def test_parse_yaml_items_line_ranges():
-    text = (
-        "requirements:\n"
-        "  - id: REQ_001\n"
-        "    title: Test\n"
-        "    significance: shall\n"
-        "  - id: REQ_002\n"
-        "    title: Second\n"
-    )
-    items = _parse_yaml_items(text)
-    assert len(items) == 2
-    assert items[0].start_line == 1
-    assert items[0].id_line == 1
-    assert items[1].start_line == 4
+def test_svcs_symbols_built_from_db(ms001_project):
+    path, state = ms001_project
+    svc_file = os.path.join(path, "software_verification_cases.yml")
+    with open(svc_file) as f:
+        text = f.read()
+
+    symbols = handle_document_symbols(uri="file://" + svc_file, text=text, project=state)
+
+    assert len(symbols) > 0
+    for sym in symbols:
+        assert sym.name
+        assert sym.kind == types.SymbolKind.Key
+
+
+def test_mvrs_symbols_built_from_db(ms001_project):
+    path, state = ms001_project
+    mvr_file = os.path.join(path, "manual_verification_results.yml")
+    if not os.path.isfile(mvr_file):
+        pytest.skip("ms-001 fixture has no MVRs file")
+    with open(mvr_file) as f:
+        text = f.read()
+
+    symbols = handle_document_symbols(uri="file://" + mvr_file, text=text, project=state)
+
+    for sym in symbols:
+        assert sym.name
+        assert "pass" in sym.name or "fail" in sym.name


### PR DESCRIPTION
## Summary

- Removes the hand-rolled regex YAML parser in `lsp/features/document_symbols.py`. Document symbols are now built from the SQLite-backed `ProjectState`, the same pipeline every other LSP feature already uses.
- Adds a `ParsingConfig` dataclass (`include_line_numbers: bool`) threaded through `build_database` → `ProjectSession` → `CombinedRawDatasetsGenerator` → individual model generators. Only `ProjectState` opts in; CLI commands keep the default and incur no extra parsing.
- When opted-in, the model generators do an extra `YAML(typ="rt")` pass over the same in-memory text and capture `id → line` from `.lc.item(idx)`. Line numbers land on `RequirementData` / `SVCData` / `MVRData` and round-trip through a new nullable `source_line` column on the `requirements`, `svcs`, and `mvrs` tables.
- New `ProjectState` accessors (`get_requirements_for_yaml`, `get_svcs_for_yaml`, `get_mvrs_for_yaml`) reverse-look-up the URN from a file path and return the items belonging to that URN, sorted by source line.

## Why

`handle_document_symbols` previously parsed YAML itself with a regex parser to pull `id`, `title`, `significance`, etc., and to derive line numbers — even though `ProjectState` already held the same data, fully validated, in SQLite. Maintaining a second parser is what produced #359 (it picked up `- path: ...` entries from `implementations:` / `imports:` as requirements, yielding `name: ""` symbols VS Code rejects). Eliminating the second parser closes that whole class of bugs.

The `ParsingConfig` opt-in is deliberately not tied to the `lsp` subcommand: future commands (e.g. an `export --include-line-numbers` flag) can opt in by constructing their own config without touching the pipeline signatures.

## Trade-off

Outline reflects last-saved state, not unsaved keystrokes. `did_change` only republishes diagnostics; `did_save` and the file watcher rebuild `ProjectState`. This is consistent with how every other ProjectState-backed LSP feature in this server already behaves (hover, completion, definition, references, codelens, …).

## Closes

- Closes #359 — regex parser is deleted; the bug cannot recur.
- Closes #362 — documentSymbol now sources every field from `ProjectState`.
- Supersedes PR #360 (the abandoned section-aware regex fix on `fix/lsp-document-symbol-wrong-section`).
- Does **not** address #361 (jsonschema `$ref` resolution for `common.schema.json`) — separate issue in the LSP diagnostics path.

## Test plan

- [x] `hatch run dev:pytest --cov=reqstool tests/unit` — 561 passed
- [x] `hatch run dev:flake8` clean
- [x] `hatch run dev:black --check` clean
- [x] CLI byte-equivalence vs `main` for `status` and `report --format asciidoc` against `test_standard/ms-001`, `test_basic/ms-101`, and `reqstool-demo`
- [ ] Manual VS Code smoke: open `requirements.yml` (normal + filter-only #359 repro) and confirm outline populates / is empty appropriately
- [ ] Manual VS Code smoke: edit a title without saving → outline stale, save → outline updates