### PR TITLE
feat(mcp): auto-detect dataset from .reqstool-ai.yaml when no source given

### DIFF
--- a/src/reqstool/command.py
+++ b/src/reqstool/command.py
@@ -323,8 +323,14 @@ class Command:
         )
 
         # command: mcp
-        mcp_parser = subparsers.add_parser("mcp", help="Start the Model Context Protocol server (stdio)")
-        mcp_source_subparsers = mcp_parser.add_subparsers(dest="source", required=True)
+        mcp_parser = subparsers.add_parser(
+            "mcp",
+            help=(
+                "Start the Model Context Protocol server (stdio). "
+                "With no source, auto-detects the dataset from .reqstool-ai.yaml in cwd or an ancestor directory."
+            ),
+        )
+        mcp_source_subparsers = mcp_parser.add_subparsers(dest="source", required=False)
         self._add_subparsers_source(mcp_source_subparsers, include_report_options=False, include_filter_options=False)
 
         args = self.__parser.parse_args()
@@ -446,8 +452,32 @@ class Command:
                 file=sys.stderr,
             )
             sys.exit(1)
+
+        if getattr(mcp_args, "source", None) is None:
+            from pathlib import Path
+
+            from reqstool.common.reqstool_ai_config import CONFIG_FILENAME, find_config, resolve_system_path
+
+            config_path = find_config()
+            if config_path is None:
+                print(
+                    f"reqstool mcp: no {CONFIG_FILENAME} found from {Path.cwd()} upward; "
+                    f"either run from a project containing {CONFIG_FILENAME} or specify an explicit source "
+                    f"(e.g. `reqstool mcp local -p <path>`).",
+                    file=sys.stderr,
+                )
+                sys.exit(2)
+            try:
+                resolved = resolve_system_path(config_path)
+            except ValueError as exc:
+                print(f"reqstool mcp: {exc}", file=sys.stderr)
+                sys.exit(2)
+            location: LocationInterface = LocalLocation(path=str(resolved))
+        else:
+            location = self._get_initial_source(mcp_args)
+
         try:
-            start_server(location=self._get_initial_source(mcp_args))
+            start_server(location=location)
         except Exception as exc:
             logging.fatal("reqstool MCP server crashed: %s", exc)
             sys.exit(1)

--- a/src/reqstool/common/reqstool_ai_config.py
+++ b/src/reqstool/common/reqstool_ai_config.py
@@ -1,0 +1,40 @@
+# Copyright © LFV
+
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+CONFIG_FILENAME = ".reqstool-ai.yaml"
+
+
+def find_config(start: Optional[Path] = None) -> Optional[Path]:
+    """Walk up from `start` (default cwd) until `.reqstool-ai.yaml` is found.
+
+    Returns the absolute path to the config file, or None if not found.
+    """
+    current = (start or Path.cwd()).resolve()
+    for directory in (current, *current.parents):
+        candidate = directory / CONFIG_FILENAME
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def resolve_system_path(config_path: Path) -> Path:
+    """Read `system.path` from the config and resolve it against the config's directory.
+
+    Raises ValueError if `system` or `system.path` is missing or not a string.
+    """
+    with open(config_path) as f:
+        data = yaml.safe_load(f) or {}
+
+    system = data.get("system")
+    if not isinstance(system, dict):
+        raise ValueError(f"{config_path}: missing required 'system' mapping")
+
+    raw_path = system.get("path")
+    if not isinstance(raw_path, str) or not raw_path:
+        raise ValueError(f"{config_path}: missing required 'system.path' string")
+
+    return (config_path.parent / raw_path).resolve()

--- a/tests/integration/reqstool/mcp/test_mcp_autodetect.py
+++ b/tests/integration/reqstool/mcp/test_mcp_autodetect.py
@@ -1,0 +1,59 @@
+# Copyright © LFV
+
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from mcp.client.session import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+
+FIXTURE_DIR = Path(__file__).resolve().parents[3] / "fixtures" / "reqstool-regression-python"
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio(loop_scope="session")]
+
+
+@pytest_asyncio.fixture(loop_scope="session", scope="module")
+async def autodetect_mcp_session(tmp_path_factory):
+    """Launch `reqstool mcp` (no source) from a dir containing .reqstool-ai.yaml."""
+    project_root = tmp_path_factory.mktemp("autodetect_project")
+    config = project_root / ".reqstool-ai.yaml"
+    config.write_text(f"system:\n  path: {FIXTURE_DIR}\n")
+
+    ready: asyncio.Queue = asyncio.Queue()
+    done = asyncio.Event()
+
+    async def _lifecycle():
+        params = StdioServerParameters(
+            command=sys.executable,
+            args=["-m", "reqstool.command", "mcp"],
+            cwd=str(project_root),
+        )
+        try:
+            async with stdio_client(params) as (read, write):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    await ready.put(session)
+                    await done.wait()
+        except Exception as exc:
+            await ready.put(exc)
+
+    task = asyncio.create_task(_lifecycle())
+    result = await ready.get()
+    if isinstance(result, Exception):
+        raise result
+
+    yield result
+
+    done.set()
+    await task
+
+
+async def test_autodetect_serves_tools(autodetect_mcp_session):
+    """Bare `reqstool mcp` resolves dataset from .reqstool-ai.yaml and serves tools."""
+    result = await autodetect_mcp_session.list_tools()
+    tool_names = {t.name for t in result.tools}
+    assert "list_requirements" in tool_names
+    assert "get_requirement" in tool_names

--- a/tests/unit/reqstool/common/test_reqstool_ai_config.py
+++ b/tests/unit/reqstool/common/test_reqstool_ai_config.py
@@ -1,0 +1,70 @@
+# Copyright © LFV
+
+from pathlib import Path
+
+import pytest
+
+from reqstool.common.reqstool_ai_config import CONFIG_FILENAME, find_config, resolve_system_path
+
+
+def test_find_config_in_cwd(tmp_path: Path, monkeypatch):
+    cfg = tmp_path / CONFIG_FILENAME
+    cfg.write_text("system:\n  path: docs/reqstool\n")
+    monkeypatch.chdir(tmp_path)
+    assert find_config() == cfg.resolve()
+
+
+def test_find_config_in_ancestor(tmp_path: Path):
+    cfg = tmp_path / CONFIG_FILENAME
+    cfg.write_text("system:\n  path: docs/reqstool\n")
+    deep = tmp_path / "a" / "b" / "c"
+    deep.mkdir(parents=True)
+    assert find_config(start=deep) == cfg.resolve()
+
+
+def test_find_config_missing(tmp_path: Path):
+    assert find_config(start=tmp_path) is None
+
+
+def test_resolve_system_path_relative(tmp_path: Path):
+    cfg = tmp_path / CONFIG_FILENAME
+    cfg.write_text("system:\n  path: docs/reqstool\n")
+    assert resolve_system_path(cfg) == (tmp_path / "docs" / "reqstool").resolve()
+
+
+def test_resolve_system_path_absolute(tmp_path: Path):
+    target = tmp_path / "elsewhere"
+    cfg = tmp_path / CONFIG_FILENAME
+    cfg.write_text(f"system:\n  path: {target}\n")
+    assert resolve_system_path(cfg) == target.resolve()
+
+
+def test_resolve_system_path_missing_system(tmp_path: Path):
+    cfg = tmp_path / CONFIG_FILENAME
+    cfg.write_text("urn: x\n")
+    with pytest.raises(ValueError, match="missing required 'system' mapping"):
+        resolve_system_path(cfg)
+
+
+def test_resolve_system_path_missing_path(tmp_path: Path):
+    cfg = tmp_path / CONFIG_FILENAME
+    cfg.write_text("system:\n  not_path: y\n")
+    with pytest.raises(ValueError, match="missing required 'system.path' string"):
+        resolve_system_path(cfg)
+
+
+def test_resolve_system_path_empty_file(tmp_path: Path):
+    cfg = tmp_path / CONFIG_FILENAME
+    cfg.write_text("")
+    with pytest.raises(ValueError, match="missing required 'system' mapping"):
+        resolve_system_path(cfg)
+
+
+def test_find_config_stops_at_first_match(tmp_path: Path):
+    outer_cfg = tmp_path / CONFIG_FILENAME
+    outer_cfg.write_text("system:\n  path: outer\n")
+    inner = tmp_path / "inner"
+    inner.mkdir()
+    inner_cfg = inner / CONFIG_FILENAME
+    inner_cfg.write_text("system:\n  path: inner\n")
+    assert find_config(start=inner) == inner_cfg.resolve()

--- a/tests/unit/reqstool/test_command.py
+++ b/tests/unit/reqstool/test_command.py
@@ -170,3 +170,16 @@ def test_pypi_source_parser_requires_package_and_version():
     assert args.source == "pypi"
     assert args.package == "my-package"
     assert args.version == "2.3.4"
+
+
+def test_mcp_parses_without_source():
+    args = _make_command_and_parse(["reqstool", "mcp"])
+    assert args.command == "mcp"
+    assert args.source is None
+
+
+def test_mcp_still_accepts_local_source():
+    args = _make_command_and_parse(["reqstool", "mcp", "local", "-p", "/some/path"])
+    assert args.command == "mcp"
+    assert args.source == "local"
+    assert args.path == "/some/path"


### PR DESCRIPTION
## Summary

- Bare `reqstool mcp` now walks up from cwd to find `.reqstool-ai.yaml` and serves `system.path` from it.
- Existing explicit forms (`mcp local -p ...`, `mcp git ...`, etc.) are unchanged.
- New shared utility `src/reqstool/common/reqstool_ai_config.py` (`find_config`, `resolve_system_path`) — designed for reuse by `reqstool render` (#352).

This makes `.mcp.json` shareable across contributors without hardcoded absolute paths and mirrors how `reqstool lsp` already runs bare.

### Behaviour

| Invocation | Result |
|------------|--------|
| `reqstool mcp` (no source), `.reqstool-ai.yaml` found | Resolve `system.path` relative to config dir → `LocalLocation` |
| `reqstool mcp` (no source), no config | Exit 2 with message pointing to both options |
| `reqstool mcp local -p <path>` | Unchanged |
| `reqstool mcp git/maven/pypi …` | Unchanged |

Only `system.path` is consumed for now; `modules.*.path` is out of scope (no MCP consumer needs it yet).

Closes #353

## Test plan

- [x] Unit tests for `reqstool_ai_config` (find in cwd / ancestor / missing; resolve absolute / relative; missing keys)
- [x] Unit tests for argparse (bare `mcp` parses; `mcp local -p` still works)
- [x] Integration test launching bare `reqstool mcp` from a tmp dir with `.reqstool-ai.yaml` pointing at the regression fixture
- [x] Full unit suite (575 passed), flake8, black --check
- [x] Regression smoke (status / report) on `test_standard` and `test_basic` fixtures — identical to `main`