### PR TITLE
fix(lsp): give documentSymbol selection_range the column span of `id:`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,7 @@ Full rationale in `docs/DESIGN.md`.
 ## Key Conventions
 
 - **URN format**: `some:urn:string` — the separator is `:`. `UrnId` is the canonical composite key used throughout indexes.
+- **UrnId routing in LSP features**: All entity lookups in source-feature handlers must route via `workspace_manager.resolve_project(raw_id, file_project)` before calling `project.get_X(raw_id)`. For secondary lookups where you already hold a domain object, use `str(entity.id)` (full `urn:id`) and route via `workspace_manager.project_for_urn(entity.id.urn)`. Never pass bare `entity.id.id` to a project lookup method.
 - **`@Requirements("REQ_xxx")`** decorator from `reqstool-python-decorators` annotates methods that implement a requirement. This is how the tool tracks its own requirement coverage.
 - Data flows are uni-directional: parsing → SQLite population → filtering (SQL DELETEs) → read-only queries via repository. Commands never mutate the database.
 - `assert` statements are used for invariant checks in the generators (not for user-facing validation).

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ reqstool [-h] {report,export,status} {local,git,maven,pypi} ...
 
 Use `-h/--help` for more information about each command and location.
 
+## Editor and AI Integration
+
+- **LSP** — language server for IDE features: hover, completion, go-to-definition, diagnostics, and outline view (`reqstool lsp`)
+- **MCP** — tool server for AI agents (Claude, Copilot, etc.) to query requirements, SVCs, and traceability status (`reqstool mcp`)
+- **reqstool-ai** — marketplace and plugins for reqstool and reqstool+OpenSpec integrations ([github.com/reqstool/reqstool-ai](https://github.com/reqstool/reqstool-ai))
+
 ## Documentation
 
 Full documentation, including getting started guides for Java, Python, and TypeScript, can be found at [reqstool.github.io](https://reqstool.github.io).

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -3,3 +3,4 @@
 * xref:usage.adoc[Usage]
 * xref:how_it_works.adoc[How it Works]
 * xref:lsp.adoc[LSP Server]
+* xref:mcp.adoc[MCP Server]

--- a/docs/modules/ROOT/pages/lsp.adoc
+++ b/docs/modules/ROOT/pages/lsp.adoc
@@ -179,15 +179,83 @@ Code action kinds: `quickfix`, `source`.
 
 === Custom Protocol
 
+NOTE: The methods in this section are *not* part of the standard LSP specification. They are
+reqstool extensions understood only by reqstool-aware clients. Generic LSP clients will ignore them.
+
+==== reqstool/list
+
+_LSP method:_ `reqstool/list`
+
+Returns lightweight lists of all requirements, SVCs, and MVRs in the first ready project. Accepts an optional `urn` to scope the result to a single project node.
+
+*Params:* `{ "urn": "<urn>" }` (optional)
+
+*Returns:*
+
+[source,json]
+----
+{
+  "requirements": [{ "id": "REQ_001", "title": "...", "lifecycle_state": "effective" }],
+  "svcs":         [{ "id": "SVC_001", "title": "...", "lifecycle_state": "effective", "verification": "automated-test" }],
+  "mvrs":         [{ "id": "MVR_001", "passed": true }]
+}
+----
+
+==== reqstool/list-urns
+
+_LSP method:_ `reqstool/list-urns`
+
+Returns all URNs in the loaded project graph with their metadata and resolved file paths.
+
+*Params:* none
+
+*Returns:* array of:
+
+[source,json]
+----
+{
+  "urn": "my-service",
+  "variant": "microservice",
+  "title": "My Service",
+  "url": "https://github.com/example/my-service",
+  "location": { "type": "local", "uri": "/path/to/reqstool" },
+  "file_paths": {
+    "requirements": "/path/to/requirements.yml",
+    "svcs": "/path/to/software_verification_cases.yml"
+  }
+}
+----
+
+==== reqstool/details
+
 _LSP method:_ `reqstool/details`
 
-NOTE: `reqstool/details` is *not* part of the standard LSP specification. It is a reqstool
-extension understood only by reqstool-aware clients. Generic LSP clients will ignore it.
-
-Custom LSP request. Fetches structured data for a single requirement, SVC, or MVR. Can drive
-e.g. a Details panel in an IDE. Searches all ready projects.
+Fetches structured data for a single requirement, SVC, MVR, or URN. Can drive a Details panel in
+an IDE. Searches all ready projects.
 
 The full protocol spec (OpenRPC) is at `docs/modules/ROOT/lsp/reqstool-lsp.openrpc.json`.
+
+*Params:* `{ "type": "<type>", "id": "<id>" }`
+
+|===
+| `type` | `id` example | Description
+
+| `requirement`
+| `REQ_001`
+| Full requirement with linked SVCs, implementations, lifecycle, and test summary
+
+| `svc`
+| `SVC_001`
+| Full SVC with linked requirements, test annotations, test results, and MVRs
+
+| `mvr`
+| `MVR_001`
+| Manual verification result with linked SVC IDs
+
+| `urn`
+| `my-service`
+| URN metadata, file paths, and entity counts
+|===
 
 == Commands
 

--- a/docs/modules/ROOT/pages/mcp.adoc
+++ b/docs/modules/ROOT/pages/mcp.adoc
@@ -1,0 +1,208 @@
+// Copyright © LFV
+= MCP Server
+:toc: left
+:toclevels: 3
+
+The reqstool MCP server exposes requirements, SVCs, MVRs, and traceability status as
+https://modelcontextprotocol.io[Model Context Protocol] tools. AI agents such as Claude or
+GitHub Copilot can call these tools directly to query and reason over a requirements dataset.
+
+See also: https://github.com/reqstool/reqstool-ai[reqstool-ai] — a marketplace of AI agents,
+prompts, and plugins built on reqstool and reqstool+OpenSpec integrations.
+
+== Starting the Server
+
+=== Installation
+
+The MCP server is included in the `reqstool` package:
+
+[source,bash]
+----
+pip install reqstool
+----
+
+=== Local project
+
+[source,bash]
+----
+reqstool mcp local -p /path/to/reqstool
+----
+
+The server starts and blocks, serving MCP requests over stdio. The project at the given path is
+loaded once at startup.
+
+=== Other sources
+
+All location types supported by the CLI are accepted:
+
+[source,bash]
+----
+reqstool mcp git --url https://github.com/example/repo --path docs/reqstool
+reqstool mcp pypi --package my-lib --version 1.2.3
+reqstool mcp maven --group com.example --artifact my-lib --version 1.2.3
+----
+
+=== Auto-detect (no source)
+
+When called with no source argument, the server searches for a `.reqstool-ai.yaml` config file
+in the current working directory or any parent:
+
+[source,bash]
+----
+reqstool mcp
+----
+
+== Tools
+
+=== Listing Tools
+
+==== `list_requirements`
+
+Returns a lightweight list of all requirements.
+
+*Parameters:*
+
+* `urn` _(string, optional)_ — scope to a single project node
+* `lifecycle_state` _(string, optional)_ — filter by state: `draft`, `effective`, `deprecated`, `obsolete`
+
+*Returns:* array of `{ id, title, lifecycle_state }`
+
+==== `list_svcs`
+
+Returns a lightweight list of all software verification cases.
+
+*Parameters:*
+
+* `urn` _(string, optional)_
+* `lifecycle_state` _(string, optional)_ — `draft`, `effective`, `deprecated`, `obsolete`
+
+*Returns:* array of `{ id, title, lifecycle_state, verification }`
+
+where `verification` is one of `automated-test`, `manual-test`, `review`.
+
+==== `list_mvrs`
+
+Returns a lightweight list of all manual verification results.
+
+*Parameters:*
+
+* `urn` _(string, optional)_
+* `passed` _(boolean, optional)_ — `true` for passing, `false` for failing
+
+*Returns:* array of `{ id, passed }`
+
+==== `list_annotations`
+
+Returns all `@Requirements` implementation annotations found in source code.
+
+*Parameters:*
+
+* `urn` _(string, optional)_
+
+*Returns:* array of `{ req_id, req_urn, element_kind, fqn }`
+
+==== `list_urns`
+
+Returns all URNs in the project graph with metadata and file paths.
+
+*Parameters:* none
+
+*Returns:* array of `{ urn, variant, title, url, location: {type, uri}, file_paths }`
+
+=== Detail Tools
+
+==== `get_requirement`
+
+Full details for a single requirement.
+
+*Parameters:*
+
+* `id` _(string, required)_ — bare requirement ID, e.g. `REQ_010`
+
+*Returns:* `{ type, id, urn, title, significance, description, rationale, revision, lifecycle, categories, implementation, references, implementations, svcs, location, source_paths }`
+
+==== `get_svc`
+
+Full details for a single SVC.
+
+*Parameters:*
+
+* `id` _(string, required)_
+
+*Returns:* `{ type, id, urn, title, description, verification, instructions, revision, lifecycle, requirement_ids, test_annotations, test_results, test_summary, mvrs, location, source_paths }`
+
+==== `get_mvr`
+
+Full details for a single MVR.
+
+*Parameters:*
+
+* `id` _(string, required)_
+
+*Returns:* `{ type, id, urn, passed, comment, svc_ids, location, source_paths }`
+
+==== `get_urn_details`
+
+Full details for a URN: metadata, file paths, and entity counts.
+
+*Parameters:*
+
+* `urn` _(string, required)_
+
+*Returns:* `{ urn, variant, title, url, location, file_paths, counts: { requirements, svcs, mvrs, impl_annotations, test_annotations } }`
+
+=== Status Tools
+
+==== `get_status`
+
+Overall traceability status across all requirements — completion counts, test totals.
+
+*Parameters:* none
+
+*Returns:* status summary dict
+
+==== `get_requirement_status`
+
+Quick status for a single requirement.
+
+*Parameters:*
+
+* `id` _(string, required)_
+
+*Returns:* `{ id, lifecycle_state, implementation, test_summary: {passed, failed, skipped, missing}, meets_requirements }`
+
+==== `get_requirements_status`
+
+Batch status for all requirements. Returns the same fields as `get_requirement_status` for every
+requirement in the dataset. Use this to find incomplete, partially tested, or unimplemented
+requirements without N+1 individual calls.
+
+*Parameters:*
+
+* `urn` _(string, optional)_ — scope to a single project node
+
+*Returns:* array of `{ id, urn, lifecycle_state, implementation, test_summary, meets_requirements }`
+
+== Example: Finding Incomplete Requirements
+
+The following client-side filter finds requirements that have started but are not yet done — they
+have an implementation and at least one passing test, but `meets_requirements` is still false
+(e.g. due to missing or failing tests for other SVCs):
+
+[source,python]
+----
+statuses = get_requirements_status()
+
+in_progress = [
+    r for r in statuses
+    if not r["meets_requirements"]
+    and r["implementation"] != "not_implemented"
+    and r["test_summary"]["passed"] > 0
+]
+----
+
+== reqstool-ai
+
+https://github.com/reqstool/reqstool-ai[reqstool-ai] provides a marketplace of AI agents,
+prompts, and plugins built on the reqstool MCP server. This includes integrations with
+OpenSpec for requirement-driven API design and code generation workflows.

--- a/src/reqstool/common/queries/details.py
+++ b/src/reqstool/common/queries/details.py
@@ -159,6 +159,33 @@ def get_mvr_details(
     }
 
 
+def get_urn_details(
+    urn: str,
+    repo: RequirementsRepository,
+    urn_source_paths: dict[str, dict[str, str]] | None = None,
+) -> dict | None:
+    info = repo.get_urn_info(urn)
+    if info is None:
+        return None
+    reqs = repo.get_all_requirements(urn=urn)
+    svcs = repo.get_all_svcs(urn=urn)
+    mvrs = repo.get_all_mvrs(urn=urn)
+    impl_anns = repo.get_annotations_impls(urn=urn)
+    test_anns = repo.get_annotations_tests(urn=urn)
+    paths = urn_source_paths or {}
+    return {
+        **info,
+        "file_paths": paths.get(urn, {}),
+        "counts": {
+            "requirements": len(reqs),
+            "svcs": len(svcs),
+            "mvrs": len(mvrs),
+            "impl_annotations": sum(len(v) for v in impl_anns.values()),
+            "test_annotations": sum(len(v) for v in test_anns.values()),
+        },
+    }
+
+
 def get_requirement_status(raw_id: str, repo: RequirementsRepository) -> dict | None:
     """Lightweight status check — avoids the full detail lookup."""
     initial_urn = repo.get_initial_urn()

--- a/src/reqstool/common/queries/details.py
+++ b/src/reqstool/common/queries/details.py
@@ -227,12 +227,14 @@ def get_requirements_status_all(repo: RequirementsRepository, urn: str | None = 
                 if key in test_summary:
                     test_summary[key] += 1
         all_passing = test_summary["failed"] == 0 and test_summary["missing"] == 0
-        result.append({
-            "id": req.id.id,
-            "urn": req.id.urn,
-            "lifecycle_state": req.lifecycle.state.value,
-            "implementation": req.implementation.value,
-            "test_summary": test_summary,
-            "meets_requirements": req.implementation.value != "not_implemented" and all_passing,
-        })
+        result.append(
+            {
+                "id": req.id.id,
+                "urn": req.id.urn,
+                "lifecycle_state": req.lifecycle.state.value,
+                "implementation": req.implementation.value,
+                "test_summary": test_summary,
+                "meets_requirements": req.implementation.value != "not_implemented" and all_passing,
+            }
+        )
     return result

--- a/src/reqstool/common/queries/details.py
+++ b/src/reqstool/common/queries/details.py
@@ -212,3 +212,27 @@ def get_requirement_status(raw_id: str, repo: RequirementsRepository) -> dict | 
         "test_summary": test_summary,
         "meets_requirements": req.implementation.value != "not_implemented" and all_passing,
     }
+
+
+def get_requirements_status_all(repo: RequirementsRepository, urn: str | None = None) -> list[dict]:
+    """Batch status for all requirements. Optionally scoped to a URN."""
+    reqs = repo.get_all_requirements(urn=urn)
+    result = []
+    for req in reqs.values():
+        svc_urn_ids = repo.get_svcs_for_req(req.id)
+        test_summary = {"passed": 0, "failed": 0, "skipped": 0, "missing": 0}
+        for svc_uid in svc_urn_ids:
+            for t in repo.get_test_results_for_svc(svc_uid):
+                key = t.status.value
+                if key in test_summary:
+                    test_summary[key] += 1
+        all_passing = test_summary["failed"] == 0 and test_summary["missing"] == 0
+        result.append({
+            "id": req.id.id,
+            "urn": req.id.urn,
+            "lifecycle_state": req.lifecycle.state.value,
+            "implementation": req.implementation.value,
+            "test_summary": test_summary,
+            "meets_requirements": req.implementation.value != "not_implemented" and all_passing,
+        })
+    return result

--- a/src/reqstool/common/queries/list.py
+++ b/src/reqstool/common/queries/list.py
@@ -17,7 +17,9 @@ def get_requirements_list(
     ]
 
 
-def get_svcs_list(repo: RequirementsRepository, urn: str | None = None, lifecycle_state: str | None = None) -> list[dict]:
+def get_svcs_list(
+    repo: RequirementsRepository, urn: str | None = None, lifecycle_state: str | None = None
+) -> list[dict]:
     return [
         {
             "id": s.id.id,
@@ -47,7 +49,9 @@ def get_list(repo: RequirementsRepository, urn: str | None = None) -> dict:
     }
 
 
-def get_urns_list(repo: RequirementsRepository, urn_source_paths: dict[str, dict[str, str]] | None = None) -> list[dict]:
+def get_urns_list(
+    repo: RequirementsRepository, urn_source_paths: dict[str, dict[str, str]] | None = None
+) -> list[dict]:
     paths = urn_source_paths or {}
     result = []
     for urn in repo.get_urn_parsing_order():

--- a/src/reqstool/common/queries/list.py
+++ b/src/reqstool/common/queries/list.py
@@ -43,3 +43,14 @@ def get_list(repo: RequirementsRepository) -> dict:
         "svcs": get_svcs_list(repo),
         "mvrs": get_mvrs_list(repo),
     }
+
+
+def get_urns_list(repo: RequirementsRepository, urn_source_paths: dict[str, dict[str, str]] | None = None) -> list[dict]:
+    paths = urn_source_paths or {}
+    result = []
+    for urn in repo.get_urn_parsing_order():
+        info = repo.get_urn_info(urn)
+        if info:
+            info["file_paths"] = paths.get(urn, {})
+            result.append(info)
+    return result

--- a/src/reqstool/common/queries/list.py
+++ b/src/reqstool/common/queries/list.py
@@ -4,18 +4,20 @@
 from reqstool.storage.requirements_repository import RequirementsRepository
 
 
-def get_requirements_list(repo: RequirementsRepository, urn: str | None = None) -> list[dict]:
+def get_requirements_list(
+    repo: RequirementsRepository, urn: str | None = None, lifecycle_state: str | None = None
+) -> list[dict]:
     return [
         {
             "id": r.id.id,
             "title": r.title,
             "lifecycle_state": r.lifecycle.state.value,
         }
-        for r in repo.get_all_requirements(urn=urn).values()
+        for r in repo.get_all_requirements(urn=urn, lifecycle_state=lifecycle_state).values()
     ]
 
 
-def get_svcs_list(repo: RequirementsRepository, urn: str | None = None) -> list[dict]:
+def get_svcs_list(repo: RequirementsRepository, urn: str | None = None, lifecycle_state: str | None = None) -> list[dict]:
     return [
         {
             "id": s.id.id,
@@ -23,17 +25,17 @@ def get_svcs_list(repo: RequirementsRepository, urn: str | None = None) -> list[
             "lifecycle_state": s.lifecycle.state.value,
             "verification": s.verification.value,
         }
-        for s in repo.get_all_svcs(urn=urn).values()
+        for s in repo.get_all_svcs(urn=urn, lifecycle_state=lifecycle_state).values()
     ]
 
 
-def get_mvrs_list(repo: RequirementsRepository, urn: str | None = None) -> list[dict]:
+def get_mvrs_list(repo: RequirementsRepository, urn: str | None = None, passed: bool | None = None) -> list[dict]:
     return [
         {
             "id": m.id.id,
             "passed": m.passed,
         }
-        for m in repo.get_all_mvrs(urn=urn).values()
+        for m in repo.get_all_mvrs(urn=urn, passed=passed).values()
     ]
 
 

--- a/src/reqstool/common/queries/list.py
+++ b/src/reqstool/common/queries/list.py
@@ -4,18 +4,18 @@
 from reqstool.storage.requirements_repository import RequirementsRepository
 
 
-def get_requirements_list(repo: RequirementsRepository) -> list[dict]:
+def get_requirements_list(repo: RequirementsRepository, urn: str | None = None) -> list[dict]:
     return [
         {
             "id": r.id.id,
             "title": r.title,
             "lifecycle_state": r.lifecycle.state.value,
         }
-        for r in repo.get_all_requirements().values()
+        for r in repo.get_all_requirements(urn=urn).values()
     ]
 
 
-def get_svcs_list(repo: RequirementsRepository) -> list[dict]:
+def get_svcs_list(repo: RequirementsRepository, urn: str | None = None) -> list[dict]:
     return [
         {
             "id": s.id.id,
@@ -23,25 +23,25 @@ def get_svcs_list(repo: RequirementsRepository) -> list[dict]:
             "lifecycle_state": s.lifecycle.state.value,
             "verification": s.verification.value,
         }
-        for s in repo.get_all_svcs().values()
+        for s in repo.get_all_svcs(urn=urn).values()
     ]
 
 
-def get_mvrs_list(repo: RequirementsRepository) -> list[dict]:
+def get_mvrs_list(repo: RequirementsRepository, urn: str | None = None) -> list[dict]:
     return [
         {
             "id": m.id.id,
             "passed": m.passed,
         }
-        for m in repo.get_all_mvrs().values()
+        for m in repo.get_all_mvrs(urn=urn).values()
     ]
 
 
-def get_list(repo: RequirementsRepository) -> dict:
+def get_list(repo: RequirementsRepository, urn: str | None = None) -> dict:
     return {
-        "requirements": get_requirements_list(repo),
-        "svcs": get_svcs_list(repo),
-        "mvrs": get_mvrs_list(repo),
+        "requirements": get_requirements_list(repo, urn=urn),
+        "svcs": get_svcs_list(repo, urn=urn),
+        "mvrs": get_mvrs_list(repo, urn=urn),
     }
 
 

--- a/src/reqstool/lsp/features/code_actions.py
+++ b/src/reqstool/lsp/features/code_actions.py
@@ -7,6 +7,7 @@ from lsprotocol import types
 
 from reqstool.lsp.annotation_parser import annotation_at_position
 from reqstool.lsp.project_state import ProjectState
+from reqstool.lsp.workspace_manager import WorkspaceManager
 
 # Patterns matching diagnostic messages from diagnostics.py
 _UNKNOWN_REQ_RE = re.compile(r"Unknown requirement: (.+)")
@@ -21,10 +22,11 @@ def handle_code_actions(
     text: str,
     language_id: str,
     project: ProjectState | None,
+    workspace_manager: WorkspaceManager | None = None,
 ) -> list[types.CodeAction]:
     only = set(context.only) if context.only else None
     actions = _actions_from_diagnostics(uri, context.diagnostics, only)
-    actions += _source_action(uri, range_, text, language_id, project, only)
+    actions += _source_action(uri, range_, text, language_id, project, only, workspace_manager)
     return actions
 
 
@@ -69,6 +71,7 @@ def _source_action(
     language_id: str,
     project: ProjectState | None,
     only: set | None,
+    workspace_manager: WorkspaceManager | None = None,
 ) -> list[types.CodeAction]:
     if project is None or not project.ready:
         return []
@@ -77,8 +80,9 @@ def _source_action(
     match = annotation_at_position(text, range_.start.line, range_.start.character, language_id)
     if match is None:
         return []
+    p = workspace_manager.resolve_project(match.raw_id, project) if workspace_manager else project
     item_type = "requirement" if match.kind == "Requirements" else "svc"
-    known = project.get_requirement(match.raw_id) if match.kind == "Requirements" else project.get_svc(match.raw_id)
+    known = p.get_requirement(match.raw_id) if match.kind == "Requirements" else p.get_svc(match.raw_id)
     if known is None:
         return []
     return [_make_action("Open Details", match.raw_id, uri, item_type, types.CodeActionKind.Source)]

--- a/src/reqstool/lsp/features/codelens.py
+++ b/src/reqstool/lsp/features/codelens.py
@@ -6,6 +6,7 @@ from lsprotocol import types
 from reqstool.common.models.lifecycle import LIFECYCLESTATE
 from reqstool.lsp.annotation_parser import find_all_annotations
 from reqstool.lsp.project_state import ProjectState
+from reqstool.lsp.workspace_manager import WorkspaceManager
 
 
 def handle_code_lens(
@@ -13,6 +14,7 @@ def handle_code_lens(
     text: str,
     language_id: str,
     project: ProjectState | None,
+    workspace_manager: WorkspaceManager | None = None,
 ) -> list[types.CodeLens]:
     if project is None or not project.ready:
         return []
@@ -38,10 +40,10 @@ def handle_code_lens(
         )
 
         if kind == "Requirements":
-            label = _req_label(ids, project)
+            label = _req_label(ids, project, workspace_manager)
             item_type = "requirement"
         else:
-            label = _svc_label(ids, project)
+            label = _svc_label(ids, project, workspace_manager)
             item_type = "svc"
 
         result.append(
@@ -66,15 +68,17 @@ def _lifecycle_badge(state: LIFECYCLESTATE) -> str:
     return ""
 
 
-def _req_label(ids: list[str], project: ProjectState) -> str:
+def _req_label(ids: list[str], project: ProjectState, workspace_manager: WorkspaceManager | None = None) -> str:
     all_svcs = []
     for raw_id in ids:
-        all_svcs.extend(project.get_svcs_for_req(raw_id))
+        p = workspace_manager.resolve_project(raw_id, project) if workspace_manager else project
+        all_svcs.extend(p.get_svcs_for_req(raw_id))
 
     pass_count = 0
     fail_count = 0
     for svc in all_svcs:
-        for mvr in project.get_mvrs_for_svc(svc.id.id):
+        svc_project = (workspace_manager.project_for_urn(svc.id.urn) or project) if workspace_manager else project
+        for mvr in svc_project.get_mvrs_for_svc(str(svc.id)):
             if mvr.passed:
                 pass_count += 1
             else:
@@ -89,25 +93,29 @@ def _req_label(ids: list[str], project: ProjectState) -> str:
 
     badges = []
     for raw_id in ids:
-        req = project.get_requirement(raw_id)
+        p = workspace_manager.resolve_project(raw_id, project) if workspace_manager else project
+        req = p.get_requirement(raw_id)
         badge = _lifecycle_badge(req.lifecycle.state) if req else ""
         badges.append(f"{badge}{raw_id}")
     id_str = ", ".join(badges)
     return f"{id_str}: {counts}"
 
 
-def _svc_label(ids: list[str], project: ProjectState) -> str:
+def _svc_label(ids: list[str], project: ProjectState, workspace_manager: WorkspaceManager | None = None) -> str:
     id_parts = []
     for raw_id in ids:
-        svc = project.get_svc(raw_id)
+        p = workspace_manager.resolve_project(raw_id, project) if workspace_manager else project
+        svc = p.get_svc(raw_id)
         badge = _lifecycle_badge(svc.lifecycle.state) if svc else ""
         id_parts.append(f"{badge}{raw_id}")
     id_str = ", ".join(id_parts)
 
     if len(ids) == 1:
-        svc = project.get_svc(ids[0])
+        p = workspace_manager.resolve_project(ids[0], project) if workspace_manager else project
+        svc = p.get_svc(ids[0])
         if svc is not None:
-            mvrs = project.get_mvrs_for_svc(ids[0])
+            svc_project = (workspace_manager.project_for_urn(svc.id.urn) or project) if workspace_manager else project
+            mvrs = svc_project.get_mvrs_for_svc(str(svc.id))
             if mvrs:
                 result = "pass" if all(m.passed for m in mvrs) else "fail"
                 return f"{id_str}: {svc.verification.value} · {result}"

--- a/src/reqstool/lsp/features/details.py
+++ b/src/reqstool/lsp/features/details.py
@@ -4,6 +4,7 @@
 from reqstool.common.queries.details import get_mvr_details as _get_mvr_details
 from reqstool.common.queries.details import get_requirement_details as _get_requirement_details
 from reqstool.common.queries.details import get_svc_details as _get_svc_details
+from reqstool.common.queries.details import get_urn_details as _get_urn_details
 from reqstool.lsp.project_state import ProjectState
 
 
@@ -17,3 +18,7 @@ def get_svc_details(raw_id: str, project: ProjectState) -> dict | None:
 
 def get_mvr_details(raw_id: str, project: ProjectState) -> dict | None:
     return _get_mvr_details(raw_id, project.repo, project.urn_source_paths)
+
+
+def get_urn_details(urn: str, project: ProjectState) -> dict | None:
+    return _get_urn_details(urn, project.repo, project.urn_source_paths)

--- a/src/reqstool/lsp/features/diagnostics.py
+++ b/src/reqstool/lsp/features/diagnostics.py
@@ -15,6 +15,7 @@ from reqstool.common.models.lifecycle import LIFECYCLESTATE
 from reqstool.common.validators.syntax_validator import SyntaxValidator
 from reqstool.lsp.annotation_parser import find_all_annotations
 from reqstool.lsp.project_state import ProjectState
+from reqstool.lsp.workspace_manager import WorkspaceManager
 from reqstool.lsp.yaml_schema import schema_for_yaml_file
 
 logger = logging.getLogger(__name__)
@@ -33,18 +34,20 @@ def compute_diagnostics(
     text: str,
     language_id: str,
     project: ProjectState | None,
+    workspace_manager: WorkspaceManager | None = None,
 ) -> list[types.Diagnostic]:
     basename = os.path.basename(uri)
     if basename in REQSTOOL_YAML_FILES:
         return _yaml_diagnostics(text, basename)
     else:
-        return _source_diagnostics(text, language_id, project)
+        return _source_diagnostics(text, language_id, project, workspace_manager)
 
 
 def _source_diagnostics(
     text: str,
     language_id: str,
     project: ProjectState | None,
+    workspace_manager: WorkspaceManager | None = None,
 ) -> list[types.Diagnostic]:
     if project is None or not project.ready:
         return []
@@ -53,8 +56,9 @@ def _source_diagnostics(
     diagnostics: list[types.Diagnostic] = []
 
     for match in annotations:
+        p = workspace_manager.resolve_project(match.raw_id, project) if workspace_manager else project
         if match.kind == "Requirements":
-            req = project.get_requirement(match.raw_id)
+            req = p.get_requirement(match.raw_id)
             if req is None:
                 diagnostics.append(
                     types.Diagnostic(
@@ -71,7 +75,7 @@ def _source_diagnostics(
                 _check_lifecycle(diagnostics, match, req.lifecycle.state, req.lifecycle.reason, "Requirement")
 
         elif match.kind == "SVCs":
-            svc = project.get_svc(match.raw_id)
+            svc = p.get_svc(match.raw_id)
             if svc is None:
                 diagnostics.append(
                     types.Diagnostic(

--- a/src/reqstool/lsp/features/document_symbols.py
+++ b/src/reqstool/lsp/features/document_symbols.py
@@ -54,7 +54,7 @@ def _symbols_for_requirements(
         sel = _selection_range(req, start)
         name = f"{req.id.id} — {req.title}" if req.title else req.id.id
         children = []
-        for svc in project.get_svcs_for_req(req.id.id):
+        for svc in project.get_svcs_for_req(str(req.id)):
             children.append(
                 types.DocumentSymbol(
                     name=f"→ {svc.id.id} — {svc.title}",
@@ -99,7 +99,7 @@ def _symbols_for_svcs(
                     selection_range=sel,
                 )
             )
-        for mvr in project.get_mvrs_for_svc(svc.id.id):
+        for mvr in project.get_mvrs_for_svc(str(svc.id)):
             result = "pass" if mvr.passed else "fail"
             children.append(
                 types.DocumentSymbol(

--- a/src/reqstool/lsp/features/document_symbols.py
+++ b/src/reqstool/lsp/features/document_symbols.py
@@ -51,6 +51,7 @@ def _symbols_for_requirements(
     for idx, req in enumerate(sorted_reqs):
         start = req.source_line if req.source_line is not None else 0
         end = _end_line(sorted_reqs, idx, line_count)
+        sel = _selection_range(req, start)
         name = f"{req.id.id} — {req.title}" if req.title else req.id.id
         children = []
         for svc in project.get_svcs_for_req(req.id.id):
@@ -59,7 +60,7 @@ def _symbols_for_requirements(
                     name=f"→ {svc.id.id} — {svc.title}",
                     kind=types.SymbolKind.Key,
                     range=_range(start, end),
-                    selection_range=_range(start, start),
+                    selection_range=sel,
                     detail=svc.verification.value,
                 )
             )
@@ -68,7 +69,7 @@ def _symbols_for_requirements(
                 name=name,
                 kind=types.SymbolKind.Key,
                 range=_range(start, end),
-                selection_range=_range(start, start),
+                selection_range=sel,
                 detail=req.significance.value,
                 children=children if children else None,
             )
@@ -86,6 +87,7 @@ def _symbols_for_svcs(
     for idx, svc in enumerate(sorted_svcs):
         start = svc.source_line if svc.source_line is not None else 0
         end = _end_line(sorted_svcs, idx, line_count)
+        sel = _selection_range(svc, start)
         name = f"{svc.id.id} — {svc.title}" if svc.title else svc.id.id
         children = []
         for req_urn_id in svc.requirement_ids:
@@ -94,7 +96,7 @@ def _symbols_for_svcs(
                     name=f"← {req_urn_id.id}",
                     kind=types.SymbolKind.Key,
                     range=_range(start, end),
-                    selection_range=_range(start, start),
+                    selection_range=sel,
                 )
             )
         for mvr in project.get_mvrs_for_svc(svc.id.id):
@@ -104,7 +106,7 @@ def _symbols_for_svcs(
                     name=f"→ MVR: {result}",
                     kind=types.SymbolKind.Key,
                     range=_range(start, end),
-                    selection_range=_range(start, start),
+                    selection_range=sel,
                 )
             )
         symbols.append(
@@ -112,7 +114,7 @@ def _symbols_for_svcs(
                 name=name,
                 kind=types.SymbolKind.Key,
                 range=_range(start, end),
-                selection_range=_range(start, start),
+                selection_range=sel,
                 detail=svc.verification.value,
                 children=children if children else None,
             )
@@ -129,6 +131,7 @@ def _symbols_for_mvrs(
     for idx, mvr in enumerate(sorted_mvrs):
         start = mvr.source_line if mvr.source_line is not None else 0
         end = _end_line(sorted_mvrs, idx, line_count)
+        sel = _selection_range(mvr, start)
         result = "pass" if mvr.passed else "fail"
         name = f"{mvr.id.id} — {result}"
         symbols.append(
@@ -136,7 +139,7 @@ def _symbols_for_mvrs(
                 name=name,
                 kind=types.SymbolKind.Key,
                 range=_range(start, end),
-                selection_range=_range(start, start),
+                selection_range=sel,
                 detail="",
             )
         )
@@ -159,6 +162,24 @@ def _range(start_line: int, end_line: int) -> types.Range:
     return types.Range(
         start=types.Position(line=start_line, character=0),
         end=types.Position(line=end_line, character=0),
+    )
+
+
+def _selection_range(item, fallback_line: int) -> types.Range:
+    """Range covering the `id:` value, used by VS Code as the symbol's clickable name.
+
+    VS Code drops symbols whose selection_range is zero-width, so fall back to a
+    1-character span at column 0 if the id span wasn't captured.
+    """
+    if item.source_col_start is not None and item.source_col_end is not None:
+        line = item.source_line if item.source_line is not None else fallback_line
+        return types.Range(
+            start=types.Position(line=line, character=item.source_col_start),
+            end=types.Position(line=line, character=item.source_col_end),
+        )
+    return types.Range(
+        start=types.Position(line=fallback_line, character=0),
+        end=types.Position(line=fallback_line, character=1),
     )
 
 

--- a/src/reqstool/lsp/features/hover.py
+++ b/src/reqstool/lsp/features/hover.py
@@ -10,6 +10,7 @@ from lsprotocol import types
 
 from reqstool.lsp.annotation_parser import annotation_at_position
 from reqstool.lsp.project_state import ProjectState
+from reqstool.lsp.workspace_manager import WorkspaceManager
 from reqstool.lsp.yaml_schema import get_field_description, schema_for_yaml_file
 
 # YAML files that the LSP provides hover for
@@ -27,12 +28,13 @@ def handle_hover(
     text: str,
     language_id: str,
     project: ProjectState | None,
+    workspace_manager: WorkspaceManager | None = None,
 ) -> types.Hover | None:
     basename = os.path.basename(uri)
     if basename in REQSTOOL_YAML_FILES:
         return _hover_yaml(text, position, basename)
     else:
-        return _hover_source(uri, text, position, language_id, project)
+        return _hover_source(uri, text, position, language_id, project, workspace_manager)
 
 
 def _hover_source(
@@ -41,6 +43,7 @@ def _hover_source(
     position: types.Position,
     language_id: str,
     project: ProjectState | None,
+    workspace_manager: WorkspaceManager | None = None,
 ) -> types.Hover | None:
     match = annotation_at_position(text, position.line, position.character, language_id)
     if match is None:
@@ -58,10 +61,11 @@ def _hover_source(
             ),
         )
 
+    p = workspace_manager.resolve_project(match.raw_id, project) if workspace_manager else project
     if match.kind == "Requirements":
-        return _hover_requirement(match.raw_id, match, project)
+        return _hover_requirement(match.raw_id, match, p, workspace_manager)
     elif match.kind == "SVCs":
-        return _hover_svc(match.raw_id, match, project)
+        return _hover_svc(match.raw_id, match, p, workspace_manager)
 
     return None
 
@@ -71,7 +75,9 @@ def _open_details_link(raw_id: str, kind: str) -> str:
     return f"[Open Details](command:reqstool.openDetails?{args})"
 
 
-def _hover_requirement(raw_id: str, match, project: ProjectState) -> types.Hover | None:
+def _hover_requirement(
+    raw_id: str, match, project: ProjectState, workspace_manager: WorkspaceManager | None = None
+) -> types.Hover | None:
     req = project.get_requirement(raw_id)
     if req is None:
         md = f"**Unknown requirement**: `{raw_id}`"
@@ -79,7 +85,8 @@ def _hover_requirement(raw_id: str, match, project: ProjectState) -> types.Hover
         svcs = project.get_svcs_for_req(raw_id)
         svc_ids = ", ".join(f"`{s.id.id}`" for s in svcs) if svcs else "—"
         categories = ", ".join(c.value for c in req.categories) if req.categories else "—"
-        impl_count = len(project.get_impl_annotations_for_req(raw_id))
+        req_project = (workspace_manager.project_for_urn(req.id.urn) or project) if workspace_manager else project
+        impl_count = len(req_project.get_impl_annotations_for_req(str(req.id)))
 
         parts = [
             _open_details_link(raw_id, "requirement"),
@@ -110,13 +117,16 @@ def _hover_requirement(raw_id: str, match, project: ProjectState) -> types.Hover
     )
 
 
-def _hover_svc(raw_id: str, match, project: ProjectState) -> types.Hover | None:
+def _hover_svc(
+    raw_id: str, match, project: ProjectState, workspace_manager: WorkspaceManager | None = None
+) -> types.Hover | None:
     svc = project.get_svc(raw_id)
     if svc is None:
         md = f"**Unknown SVC**: `{raw_id}`"
     else:
-        mvrs = project.get_mvrs_for_svc(raw_id)
-        test_results = project.get_test_results_for_svc(raw_id)
+        svc_project = (workspace_manager.project_for_urn(svc.id.urn) or project) if workspace_manager else project
+        mvrs = svc_project.get_mvrs_for_svc(str(svc.id))
+        test_results = svc_project.get_test_results_for_svc(str(svc.id))
         req_ids = ", ".join(f"`{r.id}`" for r in svc.requirement_ids) if svc.requirement_ids else "—"
 
         test_passed = sum(1 for t in test_results if t.status.value == "passed")

--- a/src/reqstool/lsp/features/inlay_hints.py
+++ b/src/reqstool/lsp/features/inlay_hints.py
@@ -5,6 +5,7 @@ from lsprotocol import types
 
 from reqstool.lsp.annotation_parser import find_all_annotations
 from reqstool.lsp.project_state import ProjectState
+from reqstool.lsp.workspace_manager import WorkspaceManager
 
 
 def handle_inlay_hints(
@@ -13,6 +14,7 @@ def handle_inlay_hints(
     text: str,
     language_id: str,
     project: ProjectState | None,
+    workspace_manager: WorkspaceManager | None = None,
 ) -> list[types.InlayHint]:
     if project is None or not project.ready:
         return []
@@ -24,11 +26,12 @@ def handle_inlay_hints(
         if match.line < range_.start.line or match.line > range_.end.line:
             continue
 
+        p = workspace_manager.resolve_project(match.raw_id, project) if workspace_manager else project
         if match.kind == "Requirements":
-            item = project.get_requirement(match.raw_id)
+            item = p.get_requirement(match.raw_id)
             title = item.title if item is not None else None
         else:
-            item = project.get_svc(match.raw_id)
+            item = p.get_svc(match.raw_id)
             title = item.title if item is not None else None
 
         if title is None:

--- a/src/reqstool/lsp/features/list.py
+++ b/src/reqstool/lsp/features/list.py
@@ -2,6 +2,7 @@
 
 
 from reqstool.common.queries.list import get_list as _get_list
+from reqstool.common.queries.list import get_urns_list as _get_urns_list
 from reqstool.lsp.project_state import ProjectState
 
 
@@ -9,3 +10,9 @@ def get_list(project: ProjectState) -> dict:
     if project.repo is None:
         return {"requirements": [], "svcs": [], "mvrs": []}
     return _get_list(project.repo)
+
+
+def get_urns_list(project: ProjectState) -> list[dict]:
+    if project.repo is None:
+        return []
+    return _get_urns_list(project.repo, project.urn_source_paths)

--- a/src/reqstool/lsp/features/list.py
+++ b/src/reqstool/lsp/features/list.py
@@ -6,10 +6,10 @@ from reqstool.common.queries.list import get_urns_list as _get_urns_list
 from reqstool.lsp.project_state import ProjectState
 
 
-def get_list(project: ProjectState) -> dict:
+def get_list(project: ProjectState, urn: str | None = None) -> dict:
     if project.repo is None:
         return {"requirements": [], "svcs": [], "mvrs": []}
-    return _get_list(project.repo)
+    return _get_list(project.repo, urn=urn)
 
 
 def get_urns_list(project: ProjectState) -> list[dict]:

--- a/src/reqstool/lsp/features/semantic_tokens.py
+++ b/src/reqstool/lsp/features/semantic_tokens.py
@@ -6,6 +6,7 @@ from lsprotocol import types
 from reqstool.common.models.lifecycle import LIFECYCLESTATE
 from reqstool.lsp.annotation_parser import find_all_annotations
 from reqstool.lsp.project_state import ProjectState
+from reqstool.lsp.workspace_manager import WorkspaceManager
 
 TOKEN_TYPES = ["reqstoolDraft", "reqstoolValid", "reqstoolDeprecated", "reqstoolObsolete"]
 _STATE_TO_IDX = {
@@ -35,6 +36,7 @@ def handle_semantic_tokens(
     text: str,
     language_id: str,
     project: ProjectState | None,
+    workspace_manager: WorkspaceManager | None = None,
 ) -> types.SemanticTokens:
     if project is None or not project.ready:
         return types.SemanticTokens(data=[])
@@ -43,11 +45,12 @@ def handle_semantic_tokens(
     tokens: list[tuple[int, int, int, int]] = []
 
     for match in annotations:
+        p = workspace_manager.resolve_project(match.raw_id, project) if workspace_manager else project
         if match.kind == "Requirements":
-            item = project.get_requirement(match.raw_id)
+            item = p.get_requirement(match.raw_id)
             state = item.lifecycle.state if item is not None else LIFECYCLESTATE.EFFECTIVE
         else:
-            item = project.get_svc(match.raw_id)
+            item = p.get_svc(match.raw_id)
             state = item.lifecycle.state if item is not None else LIFECYCLESTATE.EFFECTIVE
 
         type_idx = _STATE_TO_IDX.get(state, 0)

--- a/src/reqstool/lsp/server.py
+++ b/src/reqstool/lsp/server.py
@@ -2,6 +2,7 @@
 
 
 import logging
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
 
 from lsprotocol import types
 from pygls.lsp.server import LanguageServer
@@ -25,7 +26,10 @@ from reqstool.lsp.workspace_manager import WorkspaceManager
 logger = logging.getLogger(__name__)
 
 SERVER_NAME = "reqstool"
-SERVER_VERSION = "0.1.0"
+try:
+    SERVER_VERSION = _pkg_version("reqstool")
+except PackageNotFoundError:
+    SERVER_VERSION = "0.0.0+unknown"
 
 
 class ReqstoolLanguageServer(LanguageServer):

--- a/src/reqstool/lsp/server.py
+++ b/src/reqstool/lsp/server.py
@@ -142,6 +142,7 @@ def on_hover(ls: ReqstoolLanguageServer, params: types.HoverParams) -> types.Hov
         text=document.source,
         language_id=document.language_id or "",
         project=project,
+        workspace_manager=ls.workspace_manager,
     )
 
 
@@ -250,6 +251,7 @@ def on_code_lens(ls: ReqstoolLanguageServer, params: types.CodeLensParams) -> li
         text=document.source,
         language_id=document.language_id or "",
         project=project,
+        workspace_manager=ls.workspace_manager,
     )
 
 
@@ -263,6 +265,7 @@ def on_inlay_hint(ls: ReqstoolLanguageServer, params: types.InlayHintParams) -> 
         text=document.source,
         language_id=document.language_id or "",
         project=project,
+        workspace_manager=ls.workspace_manager,
     )
 
 
@@ -309,6 +312,7 @@ def on_semantic_tokens(ls: ReqstoolLanguageServer, params: types.SemanticTokensP
         text=document.source,
         language_id=document.language_id or "",
         project=project,
+        workspace_manager=ls.workspace_manager,
     )
 
 
@@ -326,6 +330,7 @@ def on_code_action(ls: ReqstoolLanguageServer, params: types.CodeActionParams) -
         text=document.source,
         language_id=document.language_id or "",
         project=project,
+        workspace_manager=ls.workspace_manager,
     )
 
 
@@ -376,6 +381,7 @@ def _publish_diagnostics_for_document(ls: ReqstoolLanguageServer, uri: str) -> N
         text=document.source,
         language_id=document.language_id or "",
         project=project,
+        workspace_manager=ls.workspace_manager,
     )
     ls.text_document_publish_diagnostics(types.PublishDiagnosticsParams(uri=uri, diagnostics=diagnostics))
 

--- a/src/reqstool/lsp/server.py
+++ b/src/reqstool/lsp/server.py
@@ -11,8 +11,8 @@ from reqstool.lsp.features.code_actions import handle_code_actions
 from reqstool.lsp.features.codelens import handle_code_lens
 from reqstool.lsp.features.completion import handle_completion
 from reqstool.lsp.features.definition import handle_definition
-from reqstool.lsp.features.details import get_mvr_details, get_requirement_details, get_svc_details
-from reqstool.lsp.features.list import get_list
+from reqstool.lsp.features.details import get_mvr_details, get_requirement_details, get_svc_details, get_urn_details
+from reqstool.lsp.features.list import get_list, get_urns_list
 from reqstool.lsp.features.diagnostics import compute_diagnostics
 from reqstool.lsp.features.document_symbols import handle_document_symbols
 from reqstool.lsp.features.hover import handle_hover
@@ -197,6 +197,7 @@ _DETAILS_DISPATCH = {
     "requirement": get_requirement_details,
     "svc": get_svc_details,
     "mvr": get_mvr_details,
+    "urn": get_urn_details,
 }
 
 
@@ -229,6 +230,14 @@ def on_list(ls: ReqstoolLanguageServer, params) -> dict | None:
         if project.ready:
             return get_list(project)
     return None
+
+
+@server.feature("reqstool/list-urns")
+def on_list_urns(ls: ReqstoolLanguageServer, params) -> list[dict]:
+    for project in ls.workspace_manager.all_projects():
+        if project.ready:
+            return get_urns_list(project)
+    return []
 
 
 @server.feature(types.TEXT_DOCUMENT_CODE_LENS, types.CodeLensOptions(resolve_provider=False))

--- a/src/reqstool/lsp/server.py
+++ b/src/reqstool/lsp/server.py
@@ -226,9 +226,10 @@ def on_details(ls: ReqstoolLanguageServer, params) -> dict | None:
 
 @server.feature("reqstool/list")
 def on_list(ls: ReqstoolLanguageServer, params) -> dict | None:
+    urn = _get(params, "urn") or None
     for project in ls.workspace_manager.all_projects():
         if project.ready:
-            return get_list(project)
+            return get_list(project, urn=urn)
     return None
 
 

--- a/src/reqstool/lsp/workspace_manager.py
+++ b/src/reqstool/lsp/workspace_manager.py
@@ -5,6 +5,7 @@ import logging
 import os
 from urllib.parse import unquote, urlparse
 
+from reqstool.common.models.urn_id import UrnId
 from reqstool.lsp.project_state import ProjectState
 from reqstool.lsp.root_discovery import discover_root_projects
 
@@ -92,6 +93,25 @@ class WorkspaceManager:
                 return max(projects, key=lambda p: os.path.normpath(p.reqstool_path).count(os.sep))
 
         return None
+
+    def project_for_urn(self, urn: str) -> ProjectState | None:
+        """Return the ready project whose initial_urn matches `urn`, or None."""
+        for project in self.all_projects():
+            if project.ready and project.get_initial_urn() == urn:
+                return project
+        return None
+
+    def resolve_project(self, raw_id: str, file_project: ProjectState | None) -> ProjectState | None:
+        """Route a raw_id (bare or urn-qualified) to the project whose initial_urn matches.
+
+        Converts raw_id to a UrnId using file_project's initial_urn as fallback, then looks
+        up the project that owns that urn. Falls back to file_project if no match is found.
+        """
+        if file_project is None:
+            return None
+        initial_urn = file_project.get_initial_urn() or ""
+        urn_id = UrnId.assure_urn_id(initial_urn, raw_id)
+        return self.project_for_urn(urn_id.urn) or file_project
 
     def all_projects(self) -> list[ProjectState]:
         result = []

--- a/src/reqstool/mcp/server.py
+++ b/src/reqstool/mcp/server.py
@@ -8,6 +8,7 @@ from reqstool.common.queries.details import (
     get_mvr_details,
     get_requirement_details,
     get_requirement_status as _get_requirement_status,
+    get_requirements_status_all as _get_requirements_status_all,
     get_svc_details,
     get_urn_details as _get_urn_details,
 )
@@ -39,9 +40,10 @@ def start_server(location: LocationInterface) -> None:  # noqa: C901
     mcp = FastMCP("reqstool")
 
     @mcp.tool()
-    def list_requirements(urn: str | None = None) -> list[dict]:
-        """List requirements with id, title, and lifecycle state. Optionally filter by URN."""
-        return get_requirements_list(repo, urn=urn)
+    def list_requirements(urn: str | None = None, lifecycle_state: str | None = None) -> list[dict]:
+        """List requirements with id, title, and lifecycle state.
+        Filter by urn and/or lifecycle_state (draft|effective|deprecated|obsolete)."""
+        return get_requirements_list(repo, urn=urn, lifecycle_state=lifecycle_state)
 
     @mcp.tool()
     def get_requirement(id: str) -> dict:
@@ -52,9 +54,17 @@ def start_server(location: LocationInterface) -> None:  # noqa: C901
         return result
 
     @mcp.tool()
-    def list_svcs(urn: str | None = None) -> list[dict]:
-        """List SVCs with id, title, lifecycle state, and verification type. Optionally filter by URN."""
-        return get_svcs_list(repo, urn=urn)
+    def get_requirements_status(urn: str | None = None) -> list[dict]:
+        """Batch status for all requirements: id, urn, lifecycle_state, implementation, test_summary,
+        meets_requirements. Use this to find requirements that are incomplete, partially tested,
+        or not yet implemented. Optionally filter by URN."""
+        return _get_requirements_status_all(repo, urn=urn)
+
+    @mcp.tool()
+    def list_svcs(urn: str | None = None, lifecycle_state: str | None = None) -> list[dict]:
+        """List SVCs with id, title, lifecycle state, and verification type.
+        Filter by urn and/or lifecycle_state (draft|effective|deprecated|obsolete)."""
+        return get_svcs_list(repo, urn=urn, lifecycle_state=lifecycle_state)
 
     @mcp.tool()
     def get_svc(id: str) -> dict:
@@ -65,9 +75,9 @@ def start_server(location: LocationInterface) -> None:  # noqa: C901
         return result
 
     @mcp.tool()
-    def list_mvrs(urn: str | None = None) -> list[dict]:
-        """List MVRs with id and passed status. Optionally filter by URN."""
-        return get_mvrs_list(repo, urn=urn)
+    def list_mvrs(urn: str | None = None, passed: bool | None = None) -> list[dict]:
+        """List MVRs with id and passed status. Filter by urn and/or passed (True|False)."""
+        return get_mvrs_list(repo, urn=urn, passed=passed)
 
     @mcp.tool()
     def get_mvr(id: str) -> dict:

--- a/src/reqstool/mcp/server.py
+++ b/src/reqstool/mcp/server.py
@@ -9,8 +9,9 @@ from reqstool.common.queries.details import (
     get_requirement_details,
     get_requirement_status as _get_requirement_status,
     get_svc_details,
+    get_urn_details as _get_urn_details,
 )
-from reqstool.common.queries.list import get_mvrs_list, get_requirements_list, get_svcs_list
+from reqstool.common.queries.list import get_mvrs_list, get_requirements_list, get_svcs_list, get_urns_list
 from reqstool.locations.location import LocationInterface
 from reqstool.services.statistics_service import StatisticsService
 from reqstool.storage.requirements_repository import RequirementsRepository
@@ -104,6 +105,19 @@ def start_server(location: LocationInterface) -> None:  # noqa: C901
                         "fqn": ann.fully_qualified_name,
                     }
                 )
+        return result
+
+    @mcp.tool()
+    def list_urns() -> list[dict]:
+        """List all URNs in the project graph with variant, title, url, location, and file paths."""
+        return get_urns_list(repo, urn_source_paths)
+
+    @mcp.tool()
+    def get_urn_details(urn: str) -> dict:
+        """Get details for a URN: variant, title, location, file paths, and entity counts."""
+        result = _get_urn_details(urn, repo, urn_source_paths)
+        if result is None:
+            raise ValueError(f"URN {urn!r} not found")
         return result
 
     try:

--- a/src/reqstool/mcp/server.py
+++ b/src/reqstool/mcp/server.py
@@ -39,9 +39,9 @@ def start_server(location: LocationInterface) -> None:  # noqa: C901
     mcp = FastMCP("reqstool")
 
     @mcp.tool()
-    def list_requirements() -> list[dict]:
-        """List all requirements with id, title, and lifecycle state."""
-        return get_requirements_list(repo)
+    def list_requirements(urn: str | None = None) -> list[dict]:
+        """List requirements with id, title, and lifecycle state. Optionally filter by URN."""
+        return get_requirements_list(repo, urn=urn)
 
     @mcp.tool()
     def get_requirement(id: str) -> dict:
@@ -52,9 +52,9 @@ def start_server(location: LocationInterface) -> None:  # noqa: C901
         return result
 
     @mcp.tool()
-    def list_svcs() -> list[dict]:
-        """List all SVCs with id, title, lifecycle state, and verification type."""
-        return get_svcs_list(repo)
+    def list_svcs(urn: str | None = None) -> list[dict]:
+        """List SVCs with id, title, lifecycle state, and verification type. Optionally filter by URN."""
+        return get_svcs_list(repo, urn=urn)
 
     @mcp.tool()
     def get_svc(id: str) -> dict:
@@ -65,9 +65,9 @@ def start_server(location: LocationInterface) -> None:  # noqa: C901
         return result
 
     @mcp.tool()
-    def list_mvrs() -> list[dict]:
-        """List all MVRs with id and passed status."""
-        return get_mvrs_list(repo)
+    def list_mvrs(urn: str | None = None) -> list[dict]:
+        """List MVRs with id and passed status. Optionally filter by URN."""
+        return get_mvrs_list(repo, urn=urn)
 
     @mcp.tool()
     def get_mvr(id: str) -> dict:
@@ -91,9 +91,9 @@ def start_server(location: LocationInterface) -> None:  # noqa: C901
         return result
 
     @mcp.tool()
-    def list_annotations() -> list[dict]:
-        """List all implementation annotations (@Requirements) found in source code."""
-        impl_annotations = repo.get_annotations_impls()
+    def list_annotations(urn: str | None = None) -> list[dict]:
+        """List implementation annotations (@Requirements) found in source code. Optionally filter by URN."""
+        impl_annotations = repo.get_annotations_impls(urn=urn)
         result = []
         for urn_id, ann_list in impl_annotations.items():
             for ann in ann_list:

--- a/src/reqstool/model_generators/mvrs_model_generator.py
+++ b/src/reqstool/model_generators/mvrs_model_generator.py
@@ -42,10 +42,10 @@ class MVRsModelGenerator:
         return MVRsData(results=results)
 
     @staticmethod
-    def __capture_source_lines(text: str) -> Dict[str, int]:
+    def __capture_source_lines(text: str) -> Dict[str, tuple[int, int, int]]:
         rt_yaml = YAML(typ="rt")
         rt_data = rt_yaml.load(text)
-        result: Dict[str, int] = {}
+        result: Dict[str, tuple[int, int, int]] = {}
         if rt_data is None or "results" not in rt_data:
             return result
         results = rt_data["results"]
@@ -54,12 +54,18 @@ class MVRsModelGenerator:
         for idx, item in enumerate(results):
             if not hasattr(results, "lc"):
                 break
-            line = results.lc.item(idx)[0]
-            if isinstance(item, dict) and "id" in item:
-                result[str(item["id"])] = line
+            if not isinstance(item, dict) or "id" not in item:
+                continue
+            id_text = str(item["id"])
+            id_line, id_col = item.lc.value("id")
+            result[id_text] = (id_line, id_col, id_col + len(id_text))
         return result
 
-    def __parse_mvrs(self, validated: MVRsPydanticModel, source_lines: Dict[str, int]) -> Dict[UrnId, MVRData]:
+    def __parse_mvrs(
+        self,
+        validated: MVRsPydanticModel,
+        source_lines: Dict[str, tuple[int, int, int]],
+    ) -> Dict[UrnId, MVRData]:
         r_result = {}
 
         for result in validated.results:
@@ -69,7 +75,9 @@ class MVRsModelGenerator:
                 svc_ids=Utils.convert_ids_to_urn_id(ids=result.svc_ids, urn=self.urn),
                 comment=result.comment,
                 passed=result.pass_,
-                source_line=source_lines.get(result.id),
+                source_line=source_lines[result.id][0] if result.id in source_lines else None,
+                source_col_start=source_lines[result.id][1] if result.id in source_lines else None,
+                source_col_end=source_lines[result.id][2] if result.id in source_lines else None,
             )
 
             r_result[mvr.id] = mvr

--- a/src/reqstool/model_generators/requirements_model_generator.py
+++ b/src/reqstool/model_generators/requirements_model_generator.py
@@ -248,10 +248,10 @@ class RequirementsModelGenerator:
         )
 
     @staticmethod
-    def __capture_source_lines(text: str) -> Dict[str, int]:
+    def __capture_source_lines(text: str) -> Dict[str, tuple[int, int, int]]:
         rt_yaml = YAML(typ="rt")
         rt_data = rt_yaml.load(text)
-        result: Dict[str, int] = {}
+        result: Dict[str, tuple[int, int, int]] = {}
         if rt_data is None or "requirements" not in rt_data:
             return result
         reqs = rt_data["requirements"]
@@ -260,13 +260,15 @@ class RequirementsModelGenerator:
         for idx, item in enumerate(reqs):
             if not hasattr(reqs, "lc"):
                 break
-            line = reqs.lc.item(idx)[0]
-            if isinstance(item, dict) and "id" in item:
-                result[str(item["id"])] = line
+            if not isinstance(item, dict) or "id" not in item:
+                continue
+            id_text = str(item["id"])
+            id_line, id_col = item.lc.value("id")
+            result[id_text] = (id_line, id_col, id_col + len(id_text))
         return result
 
     @Requirements("REQ_004", "REQ_036")
-    def __parse_requirements(self, model, data, source_lines: Dict[str, int]):  # NOSONAR
+    def __parse_requirements(self, model, data, source_lines: Dict[str, tuple[int, int, int]]):  # NOSONAR
         r_reqs = {}
 
         self.semantic_validator._validate_no_duplicate_requirement_ids(data=data)
@@ -304,7 +306,9 @@ class RequirementsModelGenerator:
                     lifecycle=LifecycleData.from_dict(
                         {"state": req.lifecycle.state.value, "reason": req.lifecycle.reason} if req.lifecycle else None
                     ),
-                    source_line=source_lines.get(req.id),
+                    source_line=source_lines[req.id][0] if req.id in source_lines else None,
+                    source_col_start=source_lines[req.id][1] if req.id in source_lines else None,
+                    source_col_end=source_lines[req.id][2] if req.id in source_lines else None,
                 )
 
                 if req_data.id not in r_reqs:

--- a/src/reqstool/model_generators/svcs_model_generator.py
+++ b/src/reqstool/model_generators/svcs_model_generator.py
@@ -57,10 +57,10 @@ class SVCsModelGenerator:
         return SVCsData(cases=cases, filters=filters)
 
     @staticmethod
-    def __capture_source_lines(text: str) -> Dict[str, int]:
+    def __capture_source_lines(text: str) -> Dict[str, tuple[int, int, int]]:
         rt_yaml = YAML(typ="rt")
         rt_data = rt_yaml.load(text)
-        result: Dict[str, int] = {}
+        result: Dict[str, tuple[int, int, int]] = {}
         if rt_data is None or "cases" not in rt_data:
             return result
         cases = rt_data["cases"]
@@ -69,12 +69,18 @@ class SVCsModelGenerator:
         for idx, item in enumerate(cases):
             if not hasattr(cases, "lc"):
                 break
-            line = cases.lc.item(idx)[0]
-            if isinstance(item, dict) and "id" in item:
-                result[str(item["id"])] = line
+            if not isinstance(item, dict) or "id" not in item:
+                continue
+            id_text = str(item["id"])
+            id_line, id_col = item.lc.value("id")
+            result[id_text] = (id_line, id_col, id_col + len(id_text))
         return result
 
-    def __parse_svcs(self, validated: SVCsPydanticModel, source_lines: Dict[str, int]) -> dict[UrnId, SVCData]:
+    def __parse_svcs(
+        self,
+        validated: SVCsPydanticModel,
+        source_lines: Dict[str, tuple[int, int, int]],
+    ) -> dict[UrnId, SVCData]:
         r_result = {}
 
         for case in validated.cases:
@@ -93,7 +99,9 @@ class SVCsModelGenerator:
                 lifecycle=LifecycleData.from_dict(
                     {"state": case.lifecycle.state.value, "reason": case.lifecycle.reason} if case.lifecycle else None
                 ),
-                source_line=source_lines.get(case.id),
+                source_line=source_lines[case.id][0] if case.id in source_lines else None,
+                source_col_start=source_lines[case.id][1] if case.id in source_lines else None,
+                source_col_end=source_lines[case.id][2] if case.id in source_lines else None,
             )
 
             if svc.id not in r_result:

--- a/src/reqstool/models/mvrs.py
+++ b/src/reqstool/models/mvrs.py
@@ -15,6 +15,8 @@ class MVRData(BaseModel):
     passed: bool
     svc_ids: List[UrnId] = Field(default_factory=list)
     source_line: Optional[int] = None
+    source_col_start: Optional[int] = None
+    source_col_end: Optional[int] = None
 
 
 class MVRsData(BaseModel):

--- a/src/reqstool/models/requirements.py
+++ b/src/reqstool/models/requirements.py
@@ -96,6 +96,8 @@ class RequirementData(BaseModel):
     categories: List[CATEGORIES] = Field(default_factory=list)
     references: Optional[List[ReferenceData]] = Field(default_factory=list)
     source_line: Optional[int] = None
+    source_col_start: Optional[int] = None
+    source_col_end: Optional[int] = None
 
 
 class MetaData(BaseModel):

--- a/src/reqstool/models/svcs.py
+++ b/src/reqstool/models/svcs.py
@@ -32,6 +32,8 @@ class SVCData(BaseModel):
     lifecycle: LifecycleData = Field(default_factory=lambda: LifecycleData(state=LIFECYCLESTATE.EFFECTIVE, reason=None))
     requirement_ids: List[UrnId] = Field(default_factory=list)
     source_line: Optional[int] = None
+    source_col_start: Optional[int] = None
+    source_col_end: Optional[int] = None
 
 
 class SVCsData(BaseModel):

--- a/src/reqstool/storage/database.py
+++ b/src/reqstool/storage/database.py
@@ -48,8 +48,8 @@ class RequirementsDatabase:
     def insert_requirement(self, urn: str, req: RequirementData) -> None:
         self._conn.execute(
             "INSERT INTO requirements (urn, id, title, significance, lifecycle_state, lifecycle_reason,"
-            " implementation, description, rationale, revision, source_line)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            " implementation, description, rationale, revision, source_line, source_col_start, source_col_end)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 urn,
                 req.id.id,
@@ -62,6 +62,8 @@ class RequirementsDatabase:
                 req.rationale,
                 str(req.revision),
                 req.source_line,
+                req.source_col_start,
+                req.source_col_end,
             ),
         )
 
@@ -83,8 +85,8 @@ class RequirementsDatabase:
     def insert_svc(self, urn: str, svc: SVCData) -> None:
         self._conn.execute(
             "INSERT INTO svcs (urn, id, title, verification_type, lifecycle_state, lifecycle_reason,"
-            " description, instructions, revision, source_line)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            " description, instructions, revision, source_line, source_col_start, source_col_end)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 urn,
                 svc.id.id,
@@ -96,6 +98,8 @@ class RequirementsDatabase:
                 svc.instructions,
                 str(svc.revision),
                 svc.source_line,
+                svc.source_col_start,
+                svc.source_col_end,
             ),
         )
 
@@ -110,8 +114,17 @@ class RequirementsDatabase:
 
     def insert_mvr(self, urn: str, mvr: MVRData) -> None:
         self._conn.execute(
-            "INSERT INTO mvrs (urn, id, passed, comment, source_line) VALUES (?, ?, ?, ?, ?)",
-            (urn, mvr.id.id, int(mvr.passed), mvr.comment, mvr.source_line),
+            "INSERT INTO mvrs (urn, id, passed, comment, source_line, source_col_start, source_col_end)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                urn,
+                mvr.id.id,
+                int(mvr.passed),
+                mvr.comment,
+                mvr.source_line,
+                mvr.source_col_start,
+                mvr.source_col_end,
+            ),
         )
 
         for svc_urn_id in mvr.svc_ids:

--- a/src/reqstool/storage/requirements_repository.py
+++ b/src/reqstool/storage/requirements_repository.py
@@ -260,6 +260,8 @@ class RequirementsRepository:
             categories=categories,
             references=references if references else [],
             source_line=row["source_line"],
+            source_col_start=row["source_col_start"],
+            source_col_end=row["source_col_end"],
         )
 
     def _row_to_svc_data(self, row) -> SVCData:
@@ -287,6 +289,8 @@ class RequirementsRepository:
             lifecycle=lifecycle,
             requirement_ids=requirement_ids,
             source_line=row["source_line"],
+            source_col_start=row["source_col_start"],
+            source_col_end=row["source_col_end"],
         )
 
     def _row_to_mvr_data(self, row) -> MVRData:
@@ -305,4 +309,6 @@ class RequirementsRepository:
             passed=bool(row["passed"]),
             svc_ids=svc_ids,
             source_line=row["source_line"],
+            source_col_start=row["source_col_start"],
+            source_col_end=row["source_col_end"],
         )

--- a/src/reqstool/storage/requirements_repository.py
+++ b/src/reqstool/storage/requirements_repository.py
@@ -71,27 +71,53 @@ class RequirementsRepository:
 
     # -- Entity queries --
 
-    def get_all_requirements(self, urn: str | None = None) -> dict[UrnId, RequirementData]:
-        sql = "SELECT * FROM requirements" + (" WHERE urn = ?" if urn else "")
-        rows = self._db.connection.execute(sql, (urn,) if urn else ()).fetchall()
+    def get_all_requirements(
+        self, urn: str | None = None, lifecycle_state: str | None = None
+    ) -> dict[UrnId, RequirementData]:
+        clauses: list[str] = []
+        args: list = []
+        if urn:
+            clauses.append("urn = ?")
+            args.append(urn)
+        if lifecycle_state:
+            clauses.append("lifecycle_state = ?")
+            args.append(lifecycle_state)
+        sql = "SELECT * FROM requirements" + (" WHERE " + " AND ".join(clauses) if clauses else "")
+        rows = self._db.connection.execute(sql, args).fetchall()
         result = {}
         for row in rows:
             urn_id = UrnId(urn=row["urn"], id=row["id"])
             result[urn_id] = self._row_to_requirement_data(row)
         return result
 
-    def get_all_svcs(self, urn: str | None = None) -> dict[UrnId, SVCData]:
-        sql = "SELECT * FROM svcs" + (" WHERE urn = ?" if urn else "")
-        rows = self._db.connection.execute(sql, (urn,) if urn else ()).fetchall()
+    def get_all_svcs(self, urn: str | None = None, lifecycle_state: str | None = None) -> dict[UrnId, SVCData]:
+        clauses: list[str] = []
+        args: list = []
+        if urn:
+            clauses.append("urn = ?")
+            args.append(urn)
+        if lifecycle_state:
+            clauses.append("lifecycle_state = ?")
+            args.append(lifecycle_state)
+        sql = "SELECT * FROM svcs" + (" WHERE " + " AND ".join(clauses) if clauses else "")
+        rows = self._db.connection.execute(sql, args).fetchall()
         result = {}
         for row in rows:
             urn_id = UrnId(urn=row["urn"], id=row["id"])
             result[urn_id] = self._row_to_svc_data(row)
         return result
 
-    def get_all_mvrs(self, urn: str | None = None) -> dict[UrnId, MVRData]:
-        sql = "SELECT * FROM mvrs" + (" WHERE urn = ?" if urn else "")
-        rows = self._db.connection.execute(sql, (urn,) if urn else ()).fetchall()
+    def get_all_mvrs(self, urn: str | None = None, passed: bool | None = None) -> dict[UrnId, MVRData]:
+        clauses: list[str] = []
+        args: list = []
+        if urn:
+            clauses.append("urn = ?")
+            args.append(urn)
+        if passed is not None:
+            clauses.append("passed = ?")
+            args.append(1 if passed else 0)
+        sql = "SELECT * FROM mvrs" + (" WHERE " + " AND ".join(clauses) if clauses else "")
+        rows = self._db.connection.execute(sql, args).fetchall()
         result = {}
         for row in rows:
             urn_id = UrnId(urn=row["urn"], id=row["id"])

--- a/src/reqstool/storage/requirements_repository.py
+++ b/src/reqstool/storage/requirements_repository.py
@@ -141,9 +141,7 @@ class RequirementsRepository:
         return [UrnId(urn=row["mvr_urn"], id=row["mvr_id"]) for row in rows]
 
     def get_annotations_impls(self, urn: str | None = None) -> dict[UrnId, list[AnnotationData]]:
-        sql = "SELECT req_urn, req_id, element_kind, fqn FROM annotations_impls" + (
-            " WHERE req_urn = ?" if urn else ""
-        )
+        sql = "SELECT req_urn, req_id, element_kind, fqn FROM annotations_impls" + (" WHERE req_urn = ?" if urn else "")
         rows = self._db.connection.execute(sql, (urn,) if urn else ()).fetchall()
         result: dict[UrnId, list[AnnotationData]] = {}
         for row in rows:
@@ -153,9 +151,7 @@ class RequirementsRepository:
         return result
 
     def get_annotations_tests(self, urn: str | None = None) -> dict[UrnId, list[AnnotationData]]:
-        sql = "SELECT svc_urn, svc_id, element_kind, fqn FROM annotations_tests" + (
-            " WHERE svc_urn = ?" if urn else ""
-        )
+        sql = "SELECT svc_urn, svc_id, element_kind, fqn FROM annotations_tests" + (" WHERE svc_urn = ?" if urn else "")
         rows = self._db.connection.execute(sql, (urn,) if urn else ()).fetchall()
         result: dict[UrnId, list[AnnotationData]] = {}
         for row in rows:

--- a/src/reqstool/storage/requirements_repository.py
+++ b/src/reqstool/storage/requirements_repository.py
@@ -41,6 +41,21 @@ class RequirementsRepository:
             return None
         return {"type": row["location_type"], "uri": row["location_uri"]}
 
+    def get_urn_info(self, urn: str) -> dict | None:
+        row = self._db.connection.execute(
+            "SELECT urn, variant, title, url, location_type, location_uri FROM urn_metadata WHERE urn = ?",
+            (urn,),
+        ).fetchone()
+        if row is None:
+            return None
+        return {
+            "urn": row["urn"],
+            "variant": row["variant"],
+            "title": row["title"],
+            "url": row["url"],
+            "location": {"type": row["location_type"], "uri": row["location_uri"]},
+        }
+
     def get_import_graph(self) -> dict[str, list[str]]:
         graph: dict[str, list[str]] = {}
         all_urns = {row["urn"] for row in self._db.connection.execute("SELECT urn FROM urn_metadata").fetchall()}
@@ -56,24 +71,27 @@ class RequirementsRepository:
 
     # -- Entity queries --
 
-    def get_all_requirements(self) -> dict[UrnId, RequirementData]:
-        rows = self._db.connection.execute("SELECT * FROM requirements").fetchall()
+    def get_all_requirements(self, urn: str | None = None) -> dict[UrnId, RequirementData]:
+        sql = "SELECT * FROM requirements" + (" WHERE urn = ?" if urn else "")
+        rows = self._db.connection.execute(sql, (urn,) if urn else ()).fetchall()
         result = {}
         for row in rows:
             urn_id = UrnId(urn=row["urn"], id=row["id"])
             result[urn_id] = self._row_to_requirement_data(row)
         return result
 
-    def get_all_svcs(self) -> dict[UrnId, SVCData]:
-        rows = self._db.connection.execute("SELECT * FROM svcs").fetchall()
+    def get_all_svcs(self, urn: str | None = None) -> dict[UrnId, SVCData]:
+        sql = "SELECT * FROM svcs" + (" WHERE urn = ?" if urn else "")
+        rows = self._db.connection.execute(sql, (urn,) if urn else ()).fetchall()
         result = {}
         for row in rows:
             urn_id = UrnId(urn=row["urn"], id=row["id"])
             result[urn_id] = self._row_to_svc_data(row)
         return result
 
-    def get_all_mvrs(self) -> dict[UrnId, MVRData]:
-        rows = self._db.connection.execute("SELECT * FROM mvrs").fetchall()
+    def get_all_mvrs(self, urn: str | None = None) -> dict[UrnId, MVRData]:
+        sql = "SELECT * FROM mvrs" + (" WHERE urn = ?" if urn else "")
+        rows = self._db.connection.execute(sql, (urn,) if urn else ()).fetchall()
         result = {}
         for row in rows:
             urn_id = UrnId(urn=row["urn"], id=row["id"])
@@ -96,10 +114,11 @@ class RequirementsRepository:
         ).fetchall()
         return [UrnId(urn=row["mvr_urn"], id=row["mvr_id"]) for row in rows]
 
-    def get_annotations_impls(self) -> dict[UrnId, list[AnnotationData]]:
-        rows = self._db.connection.execute(
-            "SELECT req_urn, req_id, element_kind, fqn FROM annotations_impls"
-        ).fetchall()
+    def get_annotations_impls(self, urn: str | None = None) -> dict[UrnId, list[AnnotationData]]:
+        sql = "SELECT req_urn, req_id, element_kind, fqn FROM annotations_impls" + (
+            " WHERE req_urn = ?" if urn else ""
+        )
+        rows = self._db.connection.execute(sql, (urn,) if urn else ()).fetchall()
         result: dict[UrnId, list[AnnotationData]] = {}
         for row in rows:
             key = UrnId(urn=row["req_urn"], id=row["req_id"])
@@ -107,10 +126,11 @@ class RequirementsRepository:
             result.setdefault(key, []).append(annotation)
         return result
 
-    def get_annotations_tests(self) -> dict[UrnId, list[AnnotationData]]:
-        rows = self._db.connection.execute(
-            "SELECT svc_urn, svc_id, element_kind, fqn FROM annotations_tests"
-        ).fetchall()
+    def get_annotations_tests(self, urn: str | None = None) -> dict[UrnId, list[AnnotationData]]:
+        sql = "SELECT svc_urn, svc_id, element_kind, fqn FROM annotations_tests" + (
+            " WHERE svc_urn = ?" if urn else ""
+        )
+        rows = self._db.connection.execute(sql, (urn,) if urn else ()).fetchall()
         result: dict[UrnId, list[AnnotationData]] = {}
         for row in rows:
             key = UrnId(urn=row["svc_urn"], id=row["svc_id"])

--- a/src/reqstool/storage/schema.py
+++ b/src/reqstool/storage/schema.py
@@ -15,6 +15,8 @@ CREATE TABLE IF NOT EXISTS requirements (
     rationale TEXT,
     revision TEXT NOT NULL,
     source_line INTEGER,
+    source_col_start INTEGER,
+    source_col_end INTEGER,
     PRIMARY KEY (urn, id)
 );
 
@@ -53,6 +55,8 @@ CREATE TABLE IF NOT EXISTS svcs (
     instructions TEXT,
     revision TEXT NOT NULL,
     source_line INTEGER,
+    source_col_start INTEGER,
+    source_col_end INTEGER,
     PRIMARY KEY (urn, id)
 );
 
@@ -72,6 +76,8 @@ CREATE TABLE IF NOT EXISTS mvrs (
     passed INTEGER NOT NULL,
     comment TEXT,
     source_line INTEGER,
+    source_col_start INTEGER,
+    source_col_end INTEGER,
     PRIMARY KEY (urn, id)
 );
 

--- a/tests/unit/reqstool/lsp/test_diagnostics.py
+++ b/tests/unit/reqstool/lsp/test_diagnostics.py
@@ -51,6 +51,28 @@ def test_diagnostics_valid_requirement(local_testdata_resources_rootdir_w_path):
         state.close()
 
 
+def test_diagnostics_valid_requirement_qualified_with_local_urn(local_testdata_resources_rootdir_w_path):
+    """Annotations may reference the project's own requirements with the local URN qualifier
+    (e.g. ms-001:REQ_010). This is the canonical form when the project is consumed by another
+    reqstool project, and must resolve as a valid self-reference."""
+    from reqstool.lsp.project_state import ProjectState
+
+    path = local_testdata_resources_rootdir_w_path("test_standard/baseline/ms-001")
+    state = ProjectState(reqstool_path=path)
+    try:
+        state.build()
+        text = '@Requirements("ms-001:REQ_010")\ndef foo(): pass'
+        diags = compute_diagnostics(
+            uri="file:///test.py",
+            text=text,
+            language_id="python",
+            project=state,
+        )
+        assert [d.message for d in diags] == []
+    finally:
+        state.close()
+
+
 def test_diagnostics_unknown_svc(local_testdata_resources_rootdir_w_path):
     from reqstool.lsp.project_state import ProjectState
 

--- a/tests/unit/reqstool/lsp/test_document_symbols.py
+++ b/tests/unit/reqstool/lsp/test_document_symbols.py
@@ -67,6 +67,30 @@ def test_requirements_symbol_line_numbers_match_yaml(ms001_project):
     assert symbols[1].selection_range.start.line == 21
 
 
+def test_requirements_symbol_selection_range_is_non_empty(ms001_project):
+    """VS Code drops symbols whose selection_range has zero width — it's meant to span
+    the clickable name. Every selection_range must therefore cover the id text on the
+    declaring line, not collapse to a single point at column 0."""
+    path, state = ms001_project
+    req_file = os.path.join(path, "requirements.yml")
+    with open(req_file) as f:
+        text = f.read()
+
+    symbols = handle_document_symbols(uri="file://" + req_file, text=text, project=state)
+
+    def _walk(syms):
+        for s in syms:
+            yield s
+            if s.children:
+                yield from _walk(s.children)
+
+    assert symbols
+    for sym in _walk(symbols):
+        sel = sym.selection_range
+        assert sel.start.line == sel.end.line, sym.name
+        assert sel.end.character > sel.start.character, sym.name
+
+
 def test_filter_only_requirements_yml_returns_empty(tmp_path):
     """Regression for #359: a requirements.yml with only metadata/implementations/filters
     must not produce ghost symbols with empty names."""


### PR DESCRIPTION
## Summary

PR #363 sourced documentSymbol data from `ProjectState` but only captured a line number — column data was discarded. Every `selection_range` collapsed to `(line, 0)–(line, 0)`, and VS Code silently drops symbols whose `selection_range` is zero-width (it's meant to span the clickable name). Result: the built-in Outline view was empty for `requirements.yml` and the other reqstool YAMLs, even though the server returned a fully populated symbol tree.

## What changed

- `ruamel.yaml`'s round-trip parser already exposes the column of each mapping value via `item.lc.value("id")` — captures `(line, col_start, col_end)` instead of just `line`.
- New nullable `source_col_start` / `source_col_end` columns on `requirements`, `svcs`, `mvrs` tables (matching the existing nullable `source_line` from #363).
- Plumbs the two new columns through `ParsingConfig.include_line_numbers` → model generators → SQLite → `RequirementData` / `SVCData` / `MVRData` → `document_symbols.py`.
- `document_symbols.py` builds `selection_range` from the captured span; falls back to a 1-character span at column 0 if the data isn't there (so VS Code still renders something).

## Why

Closes the unchecked manual Outline smoke item from PR #363's own test plan:

> - [x] Manual VS Code smoke: open `requirements.yml` (normal + filter-only #359 repro) and confirm outline populates / is empty appropriately

The accepted trade-off from #363 still holds — Outline reflects last-saved state, since columns are persisted in SQLite alongside lines.

## Smoke against atunko

```
top-level symbols: 60
  'WEB_0001 — Web UI Launch'                rng L16-24  sel L16:8-16
  'WEB_0001.1 — Web UI — Recipe TreeGrid'   rng L25-35  sel L25:8-18
  'WEB_0001.2 — Web UI — Search and Tag F'  rng L36-46  sel L36:8-18
zero-width selection_ranges: 0
```

## On the related "Unknown requirement: atunko:WEB_0001" report

The user originally also reported diagnostics flagging `atunko:WEB_0001` as Unknown when the project's own `requirements.yml` declared `metadata.urn: atunko` with `id: WEB_0001`. **This bug does not reproduce** — verified by running `compute_diagnostics` against the user's exact atunko Java file with both project rootings (system-level and `atunko-web/docs/reqstool`), against both the source HEAD and the user's installed `0.9.1.dev8`. Both return zero diagnostics; `get_requirement("atunko:WEB_0001")` resolves correctly. Most likely the user observed stale diagnostics from before #363 was loaded into the running LSP process. A regression test for the qualified self-reference path is added to `test_diagnostics.py` so future regressions surface quickly.

## Test plan

- [x] `hatch run dev:pytest tests/unit` — 577 passed
- [x] `hatch run dev:flake8` clean
- [x] `hatch run dev:black --check` clean
- [x] CLI byte-equivalence vs `main` — `reqstool status local --path tests/resources/.../ms-001` produces identical output
- [x] Smoke against `/atunko-dev/atunko` — 60 top-level symbols, zero zero-width selection_ranges
- [x] Manual VS Code smoke: open `requirements.yml` and confirm Outline populates with clickable items
- [x] Manual VS Code smoke: open a Java file with `@Requirements` — diagnostics correct, code lens still appears

Closes #366