### PR TITLE
fix(mcp): remove script dir from sys.path to prevent subpackage shadowing

### DIFF
--- a/src/reqstool/command.py
+++ b/src/reqstool/command.py
@@ -8,7 +8,12 @@ import sys
 from typing import Optional, TextIO, Union
 
 if __package__ is None or len(__package__) == 0:
-    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+    _script_dir = os.path.abspath(os.path.dirname(__file__))
+    # Remove the script directory from sys.path: Python adds it automatically, but
+    # reqstool subpackages (e.g. mcp/) would then shadow same-named third-party packages.
+    if _script_dir in sys.path:
+        sys.path.remove(_script_dir)
+    sys.path.insert(0, os.path.abspath(os.path.join(_script_dir, "..")))
 
     from reqstool.common.utils import Utils
 

--- a/src/reqstool/lsp/features/workspace_symbols.py
+++ b/src/reqstool/lsp/features/workspace_symbols.py
@@ -34,12 +34,14 @@ def _collect_requirements(results, project, initial_urn, query_lower):
         if query_lower and query_lower not in req_id.lower() and query_lower not in req.title.lower():
             continue
         yaml_path = project.get_yaml_path(req.id.urn or initial_urn, "requirements")
-        results.append(types.WorkspaceSymbol(
-            name=f"{req.id} — {req.title}",
-            kind=types.SymbolKind.Key,
-            location=_make_location(yaml_path, req_id),
-            data={"id": str(req.id), "type": "requirement"},
-        ))
+        results.append(
+            types.WorkspaceSymbol(
+                name=f"{req.id} — {req.title}",
+                kind=types.SymbolKind.Key,
+                location=_make_location(yaml_path, req_id),
+                data={"id": str(req.id), "type": "requirement"},
+            )
+        )
 
 
 def _collect_svcs(results, project, initial_urn, query_lower):
@@ -50,12 +52,14 @@ def _collect_svcs(results, project, initial_urn, query_lower):
         if query_lower and query_lower not in svc_id.lower() and query_lower not in svc.title.lower():
             continue
         yaml_path = project.get_yaml_path(svc.id.urn or initial_urn, "svcs")
-        results.append(types.WorkspaceSymbol(
-            name=f"{svc.id} — {svc.title}",
-            kind=types.SymbolKind.Key,
-            location=_make_location(yaml_path, svc_id),
-            data={"id": str(svc.id), "type": "svc"},
-        ))
+        results.append(
+            types.WorkspaceSymbol(
+                name=f"{svc.id} — {svc.title}",
+                kind=types.SymbolKind.Key,
+                location=_make_location(yaml_path, svc_id),
+                data={"id": str(svc.id), "type": "svc"},
+            )
+        )
 
 
 def _collect_mvrs(results, project, initial_urn, query_lower):
@@ -67,12 +71,14 @@ def _collect_mvrs(results, project, initial_urn, query_lower):
         if query_lower and query_lower not in mvr_id.lower() and query_lower not in status:
             continue
         yaml_path = project.get_yaml_path(mvr.id.urn or initial_urn, "mvrs")
-        results.append(types.WorkspaceSymbol(
-            name=f"{mvr.id} — {status}",
-            kind=types.SymbolKind.Key,
-            location=_make_location(yaml_path, mvr_id),
-            data={"id": str(mvr.id), "type": "mvr"},
-        ))
+        results.append(
+            types.WorkspaceSymbol(
+                name=f"{mvr.id} — {status}",
+                kind=types.SymbolKind.Key,
+                location=_make_location(yaml_path, mvr_id),
+                data={"id": str(mvr.id), "type": "mvr"},
+            )
+        )
 
 
 def _make_location(yaml_path: str | None, bare_id: str) -> types.Location:


### PR DESCRIPTION
## Summary

- When `command.py` is run as a script (`python src/reqstool/command.py mcp ...`), Python automatically inserts its directory (`src/reqstool/`) into `sys.path[0]`
- This caused `src/reqstool/mcp/` to shadow the installed `mcp` distribution package
- `from mcp.server.fastmcp import FastMCP` inside `start_server` then resolved to `src/reqstool/mcp/` and failed with `ImportError`, making the MCP server crash immediately on startup
- Fix removes the auto-inserted script directory before inserting `src/`, so third-party packages are resolved correctly while all `reqstool.*` imports continue to work

## Test plan

- [x] `python src/reqstool/command.py mcp local -p <path>` starts the MCP server and responds to `initialize`
- [x] `python src/reqstool/command.py status local -p <path>` still works
- [x] `python src/reqstool/command.py lsp` still starts the LSP server