### PR TITLE
feat: add reqstool enrich CLI command and enrich_document MCP tool for OpenSpec document enrichment

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -288,10 +288,9 @@ export const onReadDocument: OnReadDocumentHookV1 = async (ctx, read) => {
     ctx.lifecycle.onDispose(async () => { await client?.close(); client = null })
   }
   const result = await read()
-  const kind = ctx.document.kind === 'delta-spec' ? 'spec' : ctx.document.kind
   const enriched = await client.callTool('enrich_document', {
     content: result.markdown,
-    preset: `openspec:${kind}`,
+    preset: `openspec:${ctx.document.kind}`,
   })
   return { ...result, markdown: enriched.content[0].text }
 }

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,74 +1,190 @@
-# Implementation Plan: `render` Command (Issue #352)
+# Implementation Plan: `enrich` Command + MCP Tool (Issue #352)
 
 ## Context
 
 OpenSpec files using the reqstool integration reference requirements via opaque IDs
-(e.g. `CLI_0003`, `SVC_CLI_0003`), keeping specs DRY. In a plain-text viewer these
-IDs are unreadable without context. The `render` command resolves those IDs from the
-loaded requirements database and injects title + description inline, making specs
-human-readable while reqstool remains the single source of truth.
+(e.g. `CORE_0004`, `SVC_CLI_0003`), keeping specs DRY. In a plain-text viewer these
+IDs are unreadable without context. The `enrich` command (and matching MCP tool)
+resolves those IDs from the loaded requirements database and injects titles and
+optionally further fields inline, making specs human-readable while reqstool remains
+the single source of truth.
 
-**Scope**: One-shot mode only. Daemon mode (`--stdio`) is deferred to a follow-up.
+**Scope**: one-shot CLI command + MCP tool. MVR IDs do not appear in OpenSpec files
+and are out of scope. Daemon mode (`--stdio`) is deferred to a follow-up.
+
+---
+
+## Command Interface
+
+```
+reqstool enrich [--input <file>] [-o <file>] [--fields <field,...>] [source]
+```
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--input / -i FILE` | stdin | Input file to enrich |
+| `-o / --output FILE` | stdout | Output file |
+| `--fields FIELDS` | `title` | Comma-separated fields to inject. `all` is a shorthand for every field. |
+| `source` | auto-detect | Optional location sub-command (`local -p <path>`, `git`, `maven`, `pypi`). If omitted, walks up from cwd until `.reqstool-ai.yaml` is found (same pattern as `reqstool mcp`). |
+
+### `--fields` values
+
+**Requirements**
+
+| Field | Description |
+|-------|-------------|
+| `title` | Injected inline after the ID: `ID — Title` |
+| `significance` | SHALL / SHOULD / MAY |
+| `description` | Requirement text |
+| `rationale` | Why the requirement exists |
+| `categories` | e.g. `functional-suitability` |
+| `references` | Related requirement IDs |
+| `implementation` | `in-code` or `N/A` |
+| `revision` | Semver string |
+| `lifecycle` | `effective` / `deprecated` / `obsolete` / `draft` |
+
+**SVCs**
+
+| Field | Description |
+|-------|-------------|
+| `title` | Injected inline after the ID: `ID — Title` |
+| `description` | SVC text |
+| `verification` | `automated-test` / `manual-test` / `review` / `platform` / `other` |
+| `instructions` | How to verify |
+| `requirement_ids` | Requirements this SVC covers |
+| `revision` | Semver string |
+| `lifecycle` | State |
+
+`--fields all` includes every field above that has a non-null value.
+
+---
+
+## Injection Algorithm
+
+### Two injection strategies — determined by whether `--fields` includes anything beyond `title`
+
+**Title-only** (`--fields title`, the default):
+- Scan every line for known IDs.
+- For each line: append ` — <title>` after the **rightmost** ID occurrence.
+- Stub lines (`The system SHALL implement/pass <ID>.`) pass through unchanged.
+- Works for all file types (spec.md, design.md, proposal.md, tasks.md).
+
+**Full** (`--fields` includes description or more):
+- Only inject on **colon-header lines** — lines matching `.*:\s+<ID>\s*$`
+  (e.g. `### Requirement: CORE_0004`, `#### Scenario: SVC_CORE_0004`).
+- After an enriched header line, emit `> **Field**: value` lines for each
+  requested field that is present (see output format below).
+- **Stub lines** immediately following an enriched header are **dropped**.
+  A stub is any line where the same ID appears and the line contains no other
+  significant content beyond the ID itself (detected via the same pattern match
+  used in title-only mode on the subsequent line).
+- Non-header lines and lines with no known ID pass through unchanged.
+
+### Stub detection
+
+A stub matches: `^\s*The system SHALL (implement|pass)\s+<ID>\.?\s*$`
+
+### Output format — enriched block (one `> ` line per field)
+
+```
+### Requirement: CORE_0004 — Detect Build System
+> **Significance**: SHALL
+> **Description**: The tool shall detect whether the target project uses Gradle or Maven
+> **Rationale**: All scanning operations depend on knowing the build system
+> **Categories**: functional-suitability
+> **References**: CORE_0001
+> **Lifecycle**: effective
+
+#### Scenario: SVC_CORE_0004 — Build System Detection Test
+> **Description**: Test that the scanner correctly identifies Gradle and Maven projects
+> **Verification**: automated-test
+> **Requirements**: CORE_0004
+> **Lifecycle**: effective
+```
+
+Fields with null/empty values are omitted silently.
+
+---
+
+## Shared Processing Module
+
+All text-enrichment logic lives in one module, shared between the CLI command and
+the MCP tool:
+
+```
+src/reqstool/common/enrichment/
+    __init__.py
+    enricher.py          ← _build_lookup, _make_pattern, _enrich_text, EnrichmentConfig
+```
+
+`EnrichmentConfig` dataclass:
+```python
+@dataclass(frozen=True)
+class EnrichmentConfig:
+    fields: frozenset[str]  # e.g. frozenset({"title", "description"})
+```
+
+`EnrichmentConfig.from_fields_arg("title,description")` parses the CLI string.
+`EnrichmentConfig.all()` returns the full field set.
+
+---
 
 ## Files to Create / Modify
 
 | File | Action |
 |------|--------|
-| `src/reqstool/commands/render/__init__.py` | Create (empty, copyright header) |
-| `src/reqstool/commands/render/render.py` | Create — `RenderCommand` + helpers |
-| `src/reqstool/command.py` | Modify — argparse, `command_render`, routing |
-| `tests/unit/reqstool/commands/render/__init__.py` | Create (empty) |
-| `tests/unit/reqstool/commands/render/test_render.py` | Create — unit + integration tests |
+| `src/reqstool/common/enrichment/__init__.py` | Create (empty) |
+| `src/reqstool/common/enrichment/enricher.py` | Create — shared logic |
+| `src/reqstool/commands/enrich/__init__.py` | Create (empty) |
+| `src/reqstool/commands/enrich/enrich.py` | Create — `EnrichCommand` (thin wrapper) |
+| `src/reqstool/mcp/server.py` | Modify — add `enrich_document` tool |
+| `src/reqstool/command.py` | Modify — argparse, `command_enrich`, routing |
+| `tests/unit/reqstool/common/enrichment/` | Create — unit tests for `enricher.py` |
+| `tests/unit/reqstool/commands/enrich/` | Create — integration tests |
+| `tests/resources/enrich/` | Create — static input/output fixture files |
 
-## Command Interface
+---
+
+## Static Test Fixtures
 
 ```
-reqstool render [--input <file>] [-o <file>] [source]
+tests/resources/enrich/
+    spec_title_only/
+        input.md
+        expected.md
+    spec_full/
+        input.md
+        expected.md
+    inline_title_only/
+        input.md
+        expected.md
+    no_ids/
+        input.md
+        expected.md      ← identical to input (passthrough)
 ```
 
-- `--input / -i FILE` — input file to enrich; defaults to stdin if omitted
-- `-o / --output FILE` — output file; defaults to stdout
-- `source` — optional location sub-command (`local -p <path>`, `git`, `maven`, `pypi`);
-  if omitted, auto-detects the dataset by walking up from cwd until `.reqstool-ai.yaml`
-  is found (same pattern as `reqstool mcp`)
+Test cases to cover:
+1. Spec header line → title injected inline
+2. Spec header + stub → stub removed, full block injected (`--fields all`)
+3. Multiple IDs in one document, each enriched independently
+4. Line with unknown ID → passes through unchanged
+5. Line with no ID → passes through unchanged
+6. SVC with no description → title injected, no description line emitted
+7. Inline mid-sentence ID (`--fields title` on design.md) → title appended after ID
+8. `--fields all` on a file with no colon-header lines → no enrichment (no header matches)
 
-## Transformation Example
+---
 
-Input:
-```
-### Requirement: CLI_0003
-
-#### Scenario: SVC_CLI_0003
-```
-
-Output:
-```
-### Requirement: CLI_0003 — CLI Recipe Execution
-> The tool shall execute recipes via CLI subcommand
-
-#### Scenario: SVC_CLI_0003 — Execute recipe via CLI
-> GIVEN a project directory with Java sources
-> WHEN the user runs `atunko run -r <recipe> --project-dir <path>`
-> THEN the recipe is executed against the project and results are reported
-```
-
-## Algorithm
-
-1. Build lookup `{bare_id: (title, description)}` from all requirements + SVCs.
-2. Compile a single alternation regex (sorted by length desc) with word boundaries.
-3. For each input line:
-   - If no known ID found → pass through unchanged.
-   - Otherwise take the **rightmost** match, append ` — <title>` inline, then insert
-     `> <description>` line(s) after (each description line prefixed with `> `).
-
-## `render.py` Skeleton
+## `EnrichCommand` Skeleton
 
 ```python
-@Requirements("REQ_XXX")  # replace with next available REQ from docs/reqstool/requirements.yml
-class RenderCommand:
-    def __init__(self, location: LocationInterface, input_content: str):
+@Requirements("REQ_XXX")  # next available from docs/reqstool/requirements.yml
+class EnrichCommand:
+    def __init__(self, location: LocationInterface, input_content: str,
+                 config: EnrichmentConfig):
         self.__initial_location = location
         self.__input_content = input_content
+        self.__config = config
         self.result: str = self.__run()
 
     def __run(self) -> str:
@@ -79,83 +195,101 @@ class RenderCommand:
             repo = RequirementsRepository(db)
             requirements = repo.get_all_requirements()
             svcs = repo.get_all_svcs()
-        return _enrich_text(self.__input_content, requirements, svcs)
+        return enrich_text(self.__input_content, requirements, svcs, self.__config)
 ```
 
-Helper functions (module-level, tested independently):
-- `_build_lookup(requirements, svcs) -> dict[str, tuple[str, Optional[str]]]`
-- `_make_pattern(lookup) -> re.Pattern`  — single alternation, sorted by length desc
-- `_format_description(description) -> list[str]`  — each line prefixed with `> `
-- `_enrich_text(text, requirements, svcs) -> str`  — main scan-and-inject loop
+---
+
+## MCP Tool
+
+New tool added to `src/reqstool/mcp/server.py`:
+
+```python
+@mcp.tool()
+def enrich_document(content: str, fields: str = "title") -> str:
+    """Enrich an OpenSpec document by resolving requirement/SVC IDs.
+
+    Injects titles (and optionally further fields) inline next to each known ID.
+    Use fields='all' to include all available fields.
+    """
+    config = EnrichmentConfig.from_fields_arg(fields)
+    return enrich_text(content, _session.requirements, _session.svcs, config)
+```
+
+`_session` is the existing `ProjectSession` already loaded at MCP server startup.
+
+---
 
 ## `command.py` Changes
 
-### Import (after line 35)
+**Import** (after existing command imports):
 ```python
-from reqstool.commands.render.render import RenderCommand
+from reqstool.commands.enrich.enrich import EnrichCommand
 ```
 
-### Argparse (between lines 294–296, after `status_source_subparsers`, before `# command: lsp`)
+**Argparse** (after `status_source_subparsers`, before `# command: lsp`):
 ```python
-# command: render
-render_parser = subparsers.add_parser("render", help="Enrich a document with requirement/SVC titles and descriptions. ...")
-render_parser.add_argument("--input", "-i", metavar="FILE", default=None, help="Input file to enrich (default: stdin)")
-self._add_argument_output(render_parser)
-render_source_subparsers = render_parser.add_subparsers(dest="source", required=False)
-self._add_subparsers_source(render_source_subparsers, include_report_options=False, include_filter_options=False)
+enrich_parser = subparsers.add_parser(
+    "enrich",
+    help="Enrich a document with requirement/SVC titles and descriptions. "
+         "Auto-detects dataset from .reqstool-ai.yaml if no source is given.",
+)
+enrich_parser.add_argument("--input", "-i", metavar="FILE", default=None,
+                           help="Input file (default: stdin)")
+enrich_parser.add_argument("--fields", default="title",
+                           help="Fields to inject: title,description,... or 'all' (default: title)")
+self._add_argument_output(enrich_parser)
+enrich_source_subparsers = enrich_parser.add_subparsers(dest="source", required=False)
+self._add_subparsers_source(enrich_source_subparsers,
+                            include_report_options=False, include_filter_options=False)
 ```
 
-### `command_render` method (after `command_mcp` ends, before `print_help`)
-Same auto-detection pattern as `command_mcp` (lines 461–488):
-- `find_config()` → `resolve_system_path()` → `LocalLocation`
-- Read stdin if `--input` not provided
-- Instantiate `RenderCommand`, write `result.result` to `render_args.output`
+**`command_enrich` method** (after `command_mcp`):
+- Same auto-detection pattern as `command_mcp` (find_config → resolve_system_path → LocalLocation)
+- Read stdin if `--input` not given
+- Parse `--fields` into `EnrichmentConfig`
+- Instantiate `EnrichCommand`, write `result.result` to output
 
-### Routing in `main()` (after `elif args.command == "mcp":`)
+**Routing** in `main()`:
 ```python
-elif args.command == "render":
-    command.command_render(render_args=args)
+elif args.command == "enrich":
+    command.command_enrich(enrich_args=args)
 ```
 
-## Tests
-
-Fixture: `test_basic/baseline/ms-101`
-- `REQ_101`: title `"Title REQ_101"`, description `"Description REQ_101"`
-- `SVC_101`: title `"Some Title SVC_101"`, no description
-- `SVC_201`: title `"Some Title SVC_201"`, description `"Some Description SVC_201"`
-
-Test cases:
-1. Pure unit: `_format_description(None/empty/single-line/multi-line/blank-lines)`
-2. REQ with description: title appended inline + blockquote after
-3. SVC without description: title appended, no blockquote emitted
-4. SVC with description: both title and blockquote
-5. Unknown ID: line passes through unchanged
-6. No ID: line passes through unchanged
-7. Multi-ID document: each ID line enriched independently
-8. Interspersed plain lines preserved exactly
+---
 
 ## Verification
 
 ```bash
-# Unit tests
-hatch run dev:pytest tests/unit/reqstool/commands/render/
+# Unit tests (pure, no DB)
+hatch run dev:pytest tests/unit/reqstool/common/enrichment/
 
-# Full suite (no regressions)
+# Integration tests
+hatch run dev:pytest tests/unit/reqstool/commands/enrich/
+
+# Full suite
 hatch run dev:pytest --cov=reqstool tests/unit
 
 # Format + lint
-hatch run dev:black src tests
-hatch run dev:flake8
+hatch run dev:black src tests && hatch run dev:flake8
 
-# Manual smoke (explicit source)
+# Smoke — title only (default)
 echo "### Requirement: REQ_101" | \
-  hatch run python src/reqstool/command.py render local \
-    -p tests/resources/test_data/data/local/test_basic/baseline/ms-101
+  hatch run python src/reqstool/command.py enrich \
+    local -p tests/resources/test_data/data/local/test_basic/baseline/ms-101
+
+# Smoke — all fields
+echo "### Requirement: REQ_101" | \
+  hatch run python src/reqstool/command.py enrich --fields all \
+    local -p tests/resources/test_data/data/local/test_basic/baseline/ms-101
 ```
+
+---
 
 ## Notes
 
-- `REQ_XXX` placeholder: verify next available REQ number in `docs/reqstool/requirements.yml`
-  before writing the decorator.
-- SVC fixture file is `software_verification_cases.yml` (not `svcs.yml`) — no impact on tests.
+- `REQ_XXX` placeholder: verify next available REQ number in `docs/reqstool/requirements.yml`.
+- MVR IDs do not appear in OpenSpec files — MVR enrichment is out of scope.
 - Daemon mode (`--stdio`) is out of scope for this PR.
+- The `enrich_text` function in `enricher.py` is the single implementation used by
+  both `EnrichCommand` and the MCP `enrich_document` tool.

--- a/PLAN.md
+++ b/PLAN.md
@@ -9,8 +9,7 @@ resolves those IDs from the loaded requirements database and injects titles and
 optionally further fields inline, making specs human-readable while reqstool remains
 the single source of truth.
 
-**Scope**: one-shot CLI command + MCP tool. MVR IDs do not appear in OpenSpec files
-and are out of scope. Daemon mode (`--stdio`) is deferred to a follow-up.
+**Scope**: one-shot CLI command + MCP tool. Daemon mode (`--stdio`) is deferred to a follow-up.
 
 ---
 
@@ -54,6 +53,16 @@ reqstool enrich [--input <file>] [-o <file>] [--fields <field,...>] [source]
 | `requirement_ids` | Requirements this SVC covers |
 | `revision` | Semver string |
 | `lifecycle` | State |
+
+**MVRs**
+
+MVR has no `title` field. The inline slot uses pass/fail status instead: `MVR_001 — PASSED` / `MVR_001 — FAILED`.
+
+| Field | Description |
+|-------|-------------|
+| `passed` | Injected inline: `PASSED` or `FAILED` |
+| `comment` | Free-text verification comment |
+| `svc_ids` | SVCs covered by this MVR |
 
 `--fields all` includes every field above that has a non-null value.
 
@@ -289,7 +298,7 @@ echo "### Requirement: REQ_101" | \
 ## Notes
 
 - `REQ_XXX` placeholder: verify next available REQ number in `docs/reqstool/requirements.yml`.
-- MVR IDs do not appear in OpenSpec files — MVR enrichment is out of scope.
+- MVR enrichment is supported. Inline slot uses `PASSED`/`FAILED` (no title field). Requires `repo.get_all_mvrs()` in the lookup build.
 - Daemon mode (`--stdio`) is out of scope for this PR.
 - The `enrich_text` function in `enricher.py` is the single implementation used by
   both `EnrichCommand` and the MCP `enrich_document` tool.

--- a/PLAN.md
+++ b/PLAN.md
@@ -6,143 +6,172 @@ OpenSpec files using the reqstool integration reference requirements via opaque 
 (e.g. `CORE_0004`, `SVC_CLI_0003`), keeping specs DRY. In a plain-text viewer these
 IDs are unreadable without context. The `enrich` command (and matching MCP tool)
 resolves those IDs from the loaded requirements database and injects titles and
-optionally further fields inline, making specs human-readable while reqstool remains
-the single source of truth.
+further fields inline, making specs human-readable while reqstool remains the
+single source of truth.
 
-**Scope**: one-shot CLI command + MCP tool. Daemon mode (`--stdio`) is deferred to a follow-up.
+**Scope**: one-shot CLI command + MCP tool. No preset customisation. No `--fields`
+flag. Daemon mode (`--stdio`) deferred to a follow-up.
 
 ---
 
 ## Command Interface
 
 ```
-reqstool enrich [--input <file>] [-o <file>] [--fields <field,...>] [source]
+reqstool enrich --preset <name> [--input <file>] [-o <file>] [source]
 ```
 
 | Argument | Default | Description |
 |----------|---------|-------------|
+| `--preset NAME` | **required** | Built-in preset name (see below) |
 | `--input / -i FILE` | stdin | Input file to enrich |
 | `-o / --output FILE` | stdout | Output file |
-| `--fields FIELDS` | `title` | Comma-separated fields to inject. `all` is a shorthand for every field. |
-| `source` | auto-detect | Optional location sub-command (`local -p <path>`, `git`, `maven`, `pypi`). If omitted, walks up from cwd until `.reqstool-ai.yaml` is found (same pattern as `reqstool mcp`). |
+| `source` | auto-detect | Optional location sub-command (`local -p <path>`, `git`, `maven`, `pypi`). If omitted, walks up from cwd until `.reqstool-ai.yaml` is found (same as `reqstool mcp`). |
 
-### `--fields` values
+---
 
-**Requirements**
+## Built-in Presets
 
-| Field | Description |
-|-------|-------------|
-| `title` | Injected inline after the ID: `ID — Title` |
-| `significance` | SHALL / SHOULD / MAY |
-| `description` | Requirement text |
-| `rationale` | Why the requirement exists |
-| `categories` | e.g. `functional-suitability` |
-| `references` | Related requirement IDs |
-| `implementation` | `in-code` or `N/A` |
-| `revision` | Semver string |
-| `lifecycle` | `effective` / `deprecated` / `obsolete` / `draft` |
+| Preset | Trigger | Fields | Drop stubs |
+|--------|---------|--------|------------|
+| `openspec:spec` | colon-header | all | yes |
+| `openspec:delta-spec` | colon-header | all | yes |
+| `openspec:design` | inline | title only | no |
+| `openspec:proposal` | inline | title only | no |
+| `openspec:tasks` | inline | title only | no |
 
-**SVCs**
-
-| Field | Description |
-|-------|-------------|
-| `title` | Injected inline after the ID: `ID — Title` |
-| `description` | SVC text |
-| `verification` | `automated-test` / `manual-test` / `review` / `platform` / `other` |
-| `instructions` | How to verify |
-| `requirement_ids` | Requirements this SVC covers |
-| `revision` | Semver string |
-| `lifecycle` | State |
-
-**MVRs**
-
-MVR has no `title` field. The inline slot uses pass/fail status instead: `MVR_001 — PASSED` / `MVR_001 — FAILED`.
-
-| Field | Description |
-|-------|-------------|
-| `passed` | Injected inline: `PASSED` or `FAILED` |
-| `comment` | Free-text verification comment |
-| `svc_ids` | SVCs covered by this MVR |
-
-`--fields all` includes every field above that has a non-null value.
+`openspec:delta-spec` is a named preset with identical behaviour to `openspec:spec`.
+All presets skip inline backtick spans and fenced code blocks.
 
 ---
 
 ## Injection Algorithm
 
-### Two injection strategies — determined by whether `--fields` includes anything beyond `title`
+### Trigger: colon-header (`openspec:spec`, `openspec:delta-spec`)
 
-**Title-only** (`--fields title`, the default):
-- Scan every line for known IDs.
-- For each line: append ` — <title>` after the **rightmost** ID occurrence.
-- Stub lines (`The system SHALL implement/pass <ID>.`) pass through unchanged.
-- Works for all file types (spec.md, design.md, proposal.md, tasks.md).
+1. Pre-scan: mark no-inject zones (inline backtick spans, fenced code blocks).
+2. For each line:
+   - If inside a fenced block → pass through unchanged.
+   - If line matches `.*:\s+<ID>\s*$` (ID is last token, preceded by colon) and
+     the ID is known and not in a backtick span → inject enrichment block (see below).
+   - If line matches the stub pattern for the same ID just enriched → **drop** it.
+   - Otherwise → pass through unchanged.
 
-**Full** (`--fields` includes description or more):
-- Only inject on **colon-header lines** — lines matching `.*:\s+<ID>\s*$`
-  (e.g. `### Requirement: CORE_0004`, `#### Scenario: SVC_CORE_0004`).
-- After an enriched header line, emit `> **Field**: value` lines for each
-  requested field that is present (see output format below).
-- **Stub lines** immediately following an enriched header are **dropped**.
-  A stub is any line where the same ID appears and the line contains no other
-  significant content beyond the ID itself (detected via the same pattern match
-  used in title-only mode on the subsequent line).
-- Non-header lines and lines with no known ID pass through unchanged.
+**Stub pattern**: `^\s*The system SHALL (implement|pass)\s+<ID>\.?\s*$`
 
-### Stub detection
+### Trigger: inline (`openspec:design`, `openspec:proposal`, `openspec:tasks`)
 
-A stub matches: `^\s*The system SHALL (implement|pass)\s+<ID>\.?\s*$`
+1. Pre-scan: mark no-inject zones (inline backtick spans, fenced code blocks).
+2. For each line:
+   - Find **all** occurrences of known IDs not inside no-inject zones.
+   - Process matches **right-to-left** (to preserve string positions).
+   - For each match: append ` — <title>` immediately after the ID.
+   - Every occurrence across the entire document is enriched (no deduplication).
 
-### Output format — enriched block (one `> ` line per field)
+---
+
+## Enrichment Output Format
+
+### Title injection (both triggers, all presets)
+
+Appended inline immediately after the matched ID:
+
+```
+### Requirement: CORE_0004 — Detect Build System
+```
+
+For MVRs (no title field), the inline slot uses pass/fail:
+
+```
+#### Result: MVR_001 — PASSED
+```
+
+### Block injection (colon-header trigger only)
+
+One `> **Label**: value` line per field, in canonical order, omitting null/empty fields.
+
+**REQ** field order: Significance → Description → Rationale → Categories → References →
+Implementation → Revision → Lifecycle
+
+**SVC** field order: Description → Verification → Instructions → Requirements →
+Revision → Lifecycle
+
+**MVR** field order: Comment → SVCs
 
 ```
 ### Requirement: CORE_0004 — Detect Build System
 > **Significance**: SHALL
 > **Description**: The tool shall detect whether the target project uses Gradle or Maven
 > **Rationale**: All scanning operations depend on knowing the build system
-> **Categories**: functional-suitability
-> **References**: CORE_0001
-> **Lifecycle**: effective
+> **Categories**: Functional Suitability
+> **References**: CORE_0001, CORE_0002
+> **Implementation**: In Code
+> **Revision**: 0.1.0
+> **Lifecycle**: Effective
 
 #### Scenario: SVC_CORE_0004 — Build System Detection Test
 > **Description**: Test that the scanner correctly identifies Gradle and Maven projects
-> **Verification**: automated-test
+> **Verification**: Automated Test
 > **Requirements**: CORE_0004
-> **Lifecycle**: effective
-```
+> **Lifecycle**: Effective
 
-For MVRs:
-
-```
 #### Result: MVR_001 — PASSED
 > **Comment**: Verified manually on 2026-01-15
 > **SVCs**: SVC_CORE_0001, SVC_CORE_0002
 ```
 
-Fields with null/empty values are omitted silently.
+### Value formatting
+
+- Single-word enum values → uppercase: `SHALL`, `EFFECTIVE`, `PASSED`, `FAILED`
+- Hyphenated enum values → title-case with spaces: `Automated Test`, `Manual Test`,
+  `Functional Suitability`, `Interaction Capability`, `In Code`
+- List values → comma-separated on one line: `CORE_0001, CORE_0002`
 
 ---
 
 ## Shared Processing Module
 
-All text-enrichment logic lives in one module, shared between the CLI command and
-the MCP tool:
+All text-enrichment logic lives in one module used by both the CLI command and the
+MCP tool:
 
 ```
 src/reqstool/common/enrichment/
     __init__.py
-    enricher.py          ← _build_lookup, _make_pattern, _enrich_text, EnrichmentConfig
+    enricher.py
 ```
 
-`EnrichmentConfig` dataclass:
+### `enricher.py` public surface
+
 ```python
 @dataclass(frozen=True)
 class EnrichmentConfig:
-    fields: frozenset[str]  # e.g. frozenset({"title", "description"})
+    trigger: str              # 'colon-header' | 'inline'
+    title_only: bool          # True → skip block injection
+    drop_stubs: bool
+    skip_code_spans: bool     # always True for PoC
+
+BUILT_IN_PRESETS: dict[str, EnrichmentConfig] = {
+    'openspec:spec':       EnrichmentConfig('colon-header', False, True,  True),
+    'openspec:delta-spec': EnrichmentConfig('colon-header', False, True,  True),
+    'openspec:design':     EnrichmentConfig('inline',       True,  False, True),
+    'openspec:proposal':   EnrichmentConfig('inline',       True,  False, True),
+    'openspec:tasks':      EnrichmentConfig('inline',       True,  False, True),
+}
+
+def enrich_text(
+    text: str,
+    requirements: dict[UrnId, RequirementData],
+    svcs: dict[UrnId, SVCData],
+    mvrs: dict[UrnId, MVRData],
+    config: EnrichmentConfig,
+) -> str: ...
 ```
 
-`EnrichmentConfig.from_fields_arg("title,description")` parses the CLI string.
-`EnrichmentConfig.all()` returns the full field set.
+Internal helpers (module-level, tested independently):
+- `_build_lookup(requirements, svcs, mvrs)` → `dict[str, tuple[str, ...]]`
+- `_make_pattern(lookup)` → `re.Pattern` (single alternation, sorted by length desc)
+- `_mark_no_inject_zones(text)` → list of `(start, end)` character ranges
+- `_format_block(entity, fields)` → `list[str]` of `> **Label**: value` lines
+- `_format_value(value)` → applies uppercase/title-case rules
 
 ---
 
@@ -166,29 +195,25 @@ class EnrichmentConfig:
 
 ```
 tests/resources/enrich/
-    spec_title_only/
+    spec_all_fields/
         input.md
-        expected.md
-    spec_full/
+        expected.md        ← colon-header, all fields, stubs dropped
+    spec_no_description/
         input.md
-        expected.md
+        expected.md        ← SVC with no description: no block lines emitted
     inline_title_only/
         input.md
-        expected.md
+        expected.md        ← inline mode, multiple IDs per line, every occurrence
+    inline_code_spans/
+        input.md
+        expected.md        ← IDs inside backticks and fenced blocks skipped
     no_ids/
         input.md
-        expected.md      ← identical to input (passthrough)
+        expected.md        ← identical to input (full passthrough)
+    mvr/
+        input.md
+        expected.md        ← MVR inline PASSED/FAILED + comment/svc_ids block
 ```
-
-Test cases to cover:
-1. Spec header line → title injected inline
-2. Spec header + stub → stub removed, full block injected (`--fields all`)
-3. Multiple IDs in one document, each enriched independently
-4. Line with unknown ID → passes through unchanged
-5. Line with no ID → passes through unchanged
-6. SVC with no description → title injected, no description line emitted
-7. Inline mid-sentence ID (`--fields title` on design.md) → title appended after ID
-8. `--fields all` on a file with no colon-header lines → no enrichment (no header matches)
 
 ---
 
@@ -197,8 +222,12 @@ Test cases to cover:
 ```python
 @Requirements("REQ_XXX")  # next available from docs/reqstool/requirements.yml
 class EnrichCommand:
-    def __init__(self, location: LocationInterface, input_content: str,
-                 config: EnrichmentConfig):
+    def __init__(
+        self,
+        location: LocationInterface,
+        input_content: str,
+        config: EnrichmentConfig,
+    ):
         self.__initial_location = location
         self.__input_content = input_content
         self.__config = config
@@ -212,28 +241,61 @@ class EnrichCommand:
             repo = RequirementsRepository(db)
             requirements = repo.get_all_requirements()
             svcs = repo.get_all_svcs()
-        return enrich_text(self.__input_content, requirements, svcs, self.__config)
+            mvrs = repo.get_all_mvrs()
+        return enrich_text(self.__input_content, requirements, svcs, mvrs, self.__config)
 ```
 
 ---
 
 ## MCP Tool
 
-New tool added to `src/reqstool/mcp/server.py`:
-
 ```python
 @mcp.tool()
-def enrich_document(content: str, fields: str = "title") -> str:
-    """Enrich an OpenSpec document by resolving requirement/SVC IDs.
+def enrich_document(content: str, preset: str) -> str:
+    """Enrich an OpenSpec document by resolving requirement/SVC/MVR IDs.
 
-    Injects titles (and optionally further fields) inline next to each known ID.
-    Use fields='all' to include all available fields.
+    Injects titles and further fields next to each known ID according to the
+    named preset. Both arguments are required.
+
+    Presets: openspec:spec, openspec:delta-spec, openspec:design,
+             openspec:proposal, openspec:tasks
     """
-    config = EnrichmentConfig.from_fields_arg(fields)
-    return enrich_text(content, _session.requirements, _session.svcs, config)
+    if preset not in BUILT_IN_PRESETS:
+        raise ValueError(f"Unknown preset {preset!r}. "
+                         f"Valid: {sorted(BUILT_IN_PRESETS)}")
+    config = BUILT_IN_PRESETS[preset]
+    return enrich_text(content, repo.get_all_requirements(),
+                       repo.get_all_svcs(), repo.get_all_mvrs(), config)
 ```
 
-`_session` is the existing `ProjectSession` already loaded at MCP server startup.
+`repo` is the `RequirementsRepository` already built at MCP server startup.
+
+---
+
+## openspecui Hook (reference — not built in this PR)
+
+```typescript
+// openspec/openspecui.hooks.ts
+let client: Client | null = null
+
+export const onReadDocument: OnReadDocumentHookV1 = async (ctx, read) => {
+  if (!client) {
+    const transport = new StdioClientTransport({
+      command: 'reqstool', args: ['mcp'], cwd: ctx.projectDir,
+    })
+    client = new Client({ name: 'openspecui', version: '1.0' }, {})
+    await client.connect(transport)
+    ctx.lifecycle.onDispose(async () => { await client?.close(); client = null })
+  }
+  const result = await read()
+  const kind = ctx.document.kind === 'delta-spec' ? 'spec' : ctx.document.kind
+  const enriched = await client.callTool('enrich_document', {
+    content: result.markdown,
+    preset: `openspec:${kind}`,
+  })
+  return { ...result, markdown: enriched.content[0].text }
+}
+```
 
 ---
 
@@ -242,29 +304,34 @@ def enrich_document(content: str, fields: str = "title") -> str:
 **Import** (after existing command imports):
 ```python
 from reqstool.commands.enrich.enrich import EnrichCommand
+from reqstool.common.enrichment.enricher import BUILT_IN_PRESETS, EnrichmentConfig
 ```
 
 **Argparse** (after `status_source_subparsers`, before `# command: lsp`):
 ```python
 enrich_parser = subparsers.add_parser(
     "enrich",
-    help="Enrich a document with requirement/SVC titles and descriptions. "
+    help="Enrich a document with requirement/SVC/MVR titles and descriptions. "
          "Auto-detects dataset from .reqstool-ai.yaml if no source is given.",
+)
+enrich_parser.add_argument(
+    "--preset", required=True,
+    choices=sorted(BUILT_IN_PRESETS),
+    help="Enrichment preset (e.g. openspec:spec, openspec:design)",
 )
 enrich_parser.add_argument("--input", "-i", metavar="FILE", default=None,
                            help="Input file (default: stdin)")
-enrich_parser.add_argument("--fields", default="title",
-                           help="Fields to inject: title,description,... or 'all' (default: title)")
 self._add_argument_output(enrich_parser)
 enrich_source_subparsers = enrich_parser.add_subparsers(dest="source", required=False)
 self._add_subparsers_source(enrich_source_subparsers,
-                            include_report_options=False, include_filter_options=False)
+                            include_report_options=False,
+                            include_filter_options=False)
 ```
 
 **`command_enrich` method** (after `command_mcp`):
-- Same auto-detection pattern as `command_mcp` (find_config → resolve_system_path → LocalLocation)
+- Same auto-detection pattern as `command_mcp`
 - Read stdin if `--input` not given
-- Parse `--fields` into `EnrichmentConfig`
+- Look up `BUILT_IN_PRESETS[enrich_args.preset]` → `EnrichmentConfig`
 - Instantiate `EnrichCommand`, write `result.result` to output
 
 **Routing** in `main()`:
@@ -278,7 +345,7 @@ elif args.command == "enrich":
 ## Verification
 
 ```bash
-# Unit tests (pure, no DB)
+# Unit tests (pure helpers, no DB)
 hatch run dev:pytest tests/unit/reqstool/common/enrichment/
 
 # Integration tests
@@ -290,23 +357,36 @@ hatch run dev:pytest --cov=reqstool tests/unit
 # Format + lint
 hatch run dev:black src tests && hatch run dev:flake8
 
-# Smoke — title only (default)
-echo "### Requirement: REQ_101" | \
-  hatch run python src/reqstool/command.py enrich \
+# Smoke — spec preset
+echo "### Requirement: REQ_101
+The system SHALL implement REQ_101." | \
+  hatch run python src/reqstool/command.py enrich --preset openspec:spec \
     local -p tests/resources/test_data/data/local/test_basic/baseline/ms-101
 
-# Smoke — all fields
-echo "### Requirement: REQ_101" | \
-  hatch run python src/reqstool/command.py enrich --fields all \
+# Smoke — inline preset
+echo "This implements REQ_101 and verifies SVC_201." | \
+  hatch run python src/reqstool/command.py enrich --preset openspec:design \
     local -p tests/resources/test_data/data/local/test_basic/baseline/ms-101
 ```
 
 ---
 
+## Follow-up Issues to Create
+
+- **reqstool-ai**: Implement the openspecui hook (`openspec/openspecui.hooks.ts`) that
+  starts `reqstool mcp` once per project session and calls `enrich_document` per document
+  read. Reference the hook skeleton in this plan's "openspecui Hook" section.
+
+---
+
 ## Notes
 
-- `REQ_XXX` placeholder: verify next available REQ number in `docs/reqstool/requirements.yml`.
-- MVR enrichment is supported. Inline slot uses `PASSED`/`FAILED` (no title field). Requires `repo.get_all_mvrs()` in the lookup build.
-- Daemon mode (`--stdio`) is out of scope for this PR.
-- The `enrich_text` function in `enricher.py` is the single implementation used by
-  both `EnrichCommand` and the MCP `enrich_document` tool.
+- `REQ_XXX` placeholder: check next available number in `docs/reqstool/requirements.yml`.
+- `openspec:delta-spec` is a named preset with identical behaviour to `openspec:spec`;
+  the alias mapping (`delta-spec` → spec behaviour) lives in `BUILT_IN_PRESETS`, not
+  in the hook.
+- MVR enrichment: inline slot = `PASSED`/`FAILED`; block fields = Comment, SVCs.
+- `--fields` flag deferred (no raw field selection in PoC).
+- Daemon mode (`--stdio`) deferred.
+- The openspecui hook (TypeScript) is documented here for reference but is not part
+  of this PR.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,161 @@
+# Implementation Plan: `render` Command (Issue #352)
+
+## Context
+
+Reqstool spec files use opaque IDs (e.g. `CLI_0003`, `SVC_CLI_0003`) to reference
+requirements, keeping specs DRY. In a plain-text viewer these IDs are unreadable
+without context. The `render` command resolves those IDs from the loaded requirements
+database and injects title + description inline, making specs human-readable while
+reqstool remains the single source of truth.
+
+**Scope**: One-shot mode only. Daemon mode (`--stdio`) is deferred to a follow-up.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `src/reqstool/commands/render/__init__.py` | Create (empty, copyright header) |
+| `src/reqstool/commands/render/render.py` | Create — `RenderCommand` + helpers |
+| `src/reqstool/command.py` | Modify — argparse, `command_render`, routing |
+| `tests/unit/reqstool/commands/render/__init__.py` | Create (empty) |
+| `tests/unit/reqstool/commands/render/test_render.py` | Create — unit + integration tests |
+
+## Command Interface
+
+```
+reqstool render [--input <file>] [-o <file>] [source]
+```
+
+- `--input / -i FILE` — input file to enrich; defaults to stdin if omitted
+- `-o / --output FILE` — output file; defaults to stdout
+- `source` — optional location sub-command (`local -p <path>`, `git`, `maven`, `pypi`);
+  if omitted, auto-detects the dataset by walking up from cwd until `.reqstool-ai.yaml`
+  is found (same pattern as `reqstool mcp`)
+
+## Transformation Example
+
+Input:
+```
+### Requirement: CLI_0003
+
+#### Scenario: SVC_CLI_0003
+```
+
+Output:
+```
+### Requirement: CLI_0003 — CLI Recipe Execution
+> The tool shall execute recipes via CLI subcommand
+
+#### Scenario: SVC_CLI_0003 — Execute recipe via CLI
+> GIVEN a project directory with Java sources
+> WHEN the user runs `atunko run -r <recipe> --project-dir <path>`
+> THEN the recipe is executed against the project and results are reported
+```
+
+## Algorithm
+
+1. Build lookup `{bare_id: (title, description)}` from all requirements + SVCs.
+2. Compile a single alternation regex (sorted by length desc) with word boundaries.
+3. For each input line:
+   - If no known ID found → pass through unchanged.
+   - Otherwise take the **rightmost** match, append ` — <title>` inline, then insert
+     `> <description>` line(s) after (each description line prefixed with `> `).
+
+## `render.py` Skeleton
+
+```python
+@Requirements("REQ_XXX")  # replace with next available REQ from docs/reqstool/requirements.yml
+class RenderCommand:
+    def __init__(self, location: LocationInterface, input_content: str):
+        self.__initial_location = location
+        self.__input_content = input_content
+        self.result: str = self.__run()
+
+    def __run(self) -> str:
+        with build_database(
+            location=self.__initial_location,
+            semantic_validator=SemanticValidator(validation_error_holder=ValidationErrorHolder()),
+        ) as (db, _):
+            repo = RequirementsRepository(db)
+            requirements = repo.get_all_requirements()
+            svcs = repo.get_all_svcs()
+        return _enrich_text(self.__input_content, requirements, svcs)
+```
+
+Helper functions (module-level, tested independently):
+- `_build_lookup(requirements, svcs) -> dict[str, tuple[str, Optional[str]]]`
+- `_make_pattern(lookup) -> re.Pattern`  — single alternation, sorted by length desc
+- `_format_description(description) -> list[str]`  — each line prefixed with `> `
+- `_enrich_text(text, requirements, svcs) -> str`  — main scan-and-inject loop
+
+## `command.py` Changes
+
+### Import (after line 35)
+```python
+from reqstool.commands.render.render import RenderCommand
+```
+
+### Argparse (between lines 294–296, after `status_source_subparsers`, before `# command: lsp`)
+```python
+# command: render
+render_parser = subparsers.add_parser("render", help="Enrich a document with requirement/SVC titles and descriptions. ...")
+render_parser.add_argument("--input", "-i", metavar="FILE", default=None, help="Input file to enrich (default: stdin)")
+self._add_argument_output(render_parser)
+render_source_subparsers = render_parser.add_subparsers(dest="source", required=False)
+self._add_subparsers_source(render_source_subparsers, include_report_options=False, include_filter_options=False)
+```
+
+### `command_render` method (after `command_mcp` ends, before `print_help`)
+Same auto-detection pattern as `command_mcp` (lines 461–488):
+- `find_config()` → `resolve_system_path()` → `LocalLocation`
+- Read stdin if `--input` not provided
+- Instantiate `RenderCommand`, write `result.result` to `render_args.output`
+
+### Routing in `main()` (after `elif args.command == "mcp":`)
+```python
+elif args.command == "render":
+    command.command_render(render_args=args)
+```
+
+## Tests
+
+Fixture: `test_basic/baseline/ms-101`
+- `REQ_101`: title `"Title REQ_101"`, description `"Description REQ_101"`
+- `SVC_101`: title `"Some Title SVC_101"`, no description
+- `SVC_201`: title `"Some Title SVC_201"`, description `"Some Description SVC_201"`
+
+Test cases:
+1. Pure unit: `_format_description(None/empty/single-line/multi-line/blank-lines)`
+2. REQ with description: title appended inline + blockquote after
+3. SVC without description: title appended, no blockquote emitted
+4. SVC with description: both title and blockquote
+5. Unknown ID: line passes through unchanged
+6. No ID: line passes through unchanged
+7. Multi-ID document: each ID line enriched independently
+8. Interspersed plain lines preserved exactly
+
+## Verification
+
+```bash
+# Unit tests
+hatch run dev:pytest tests/unit/reqstool/commands/render/
+
+# Full suite (no regressions)
+hatch run dev:pytest --cov=reqstool tests/unit
+
+# Format + lint
+hatch run dev:black src tests
+hatch run dev:flake8
+
+# Manual smoke (explicit source)
+echo "### Requirement: REQ_101" | \
+  hatch run python src/reqstool/command.py render local \
+    -p tests/resources/test_data/data/local/test_basic/baseline/ms-101
+```
+
+## Notes
+
+- `REQ_XXX` placeholder: verify next available REQ number in `docs/reqstool/requirements.yml`
+  before writing the decorator.
+- SVC fixture file is `software_verification_cases.yml` (not `svcs.yml`) — no impact on tests.
+- Daemon mode (`--stdio`) is out of scope for this PR.

--- a/PLAN.md
+++ b/PLAN.md
@@ -111,6 +111,14 @@ A stub matches: `^\s*The system SHALL (implement|pass)\s+<ID>\.?\s*$`
 > **Lifecycle**: effective
 ```
 
+For MVRs:
+
+```
+#### Result: MVR_001 — PASSED
+> **Comment**: Verified manually on 2026-01-15
+> **SVCs**: SVC_CORE_0001, SVC_CORE_0002
+```
+
 Fields with null/empty values are omitted silently.
 
 ---

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,11 +2,11 @@
 
 ## Context
 
-Reqstool spec files use opaque IDs (e.g. `CLI_0003`, `SVC_CLI_0003`) to reference
-requirements, keeping specs DRY. In a plain-text viewer these IDs are unreadable
-without context. The `render` command resolves those IDs from the loaded requirements
-database and injects title + description inline, making specs human-readable while
-reqstool remains the single source of truth.
+OpenSpec files using the reqstool integration reference requirements via opaque IDs
+(e.g. `CLI_0003`, `SVC_CLI_0003`), keeping specs DRY. In a plain-text viewer these
+IDs are unreadable without context. The `render` command resolves those IDs from the
+loaded requirements database and injects title + description inline, making specs
+human-readable while reqstool remains the single source of truth.
 
 **Scope**: One-shot mode only. Daemon mode (`--stdio`) is deferred to a follow-up.
 

--- a/src/reqstool/command.py
+++ b/src/reqstool/command.py
@@ -32,7 +32,9 @@ from reqstool.commands.generate_json.generate_json import GenerateJsonCommand
 from reqstool.commands.report import report
 from reqstool.commands.report.criterias.group_by import GroupbyOptions
 from reqstool.commands.report.criterias.sort_by import SortByOptions
+from reqstool.commands.enrich.enrich import EnrichCommand
 from reqstool.commands.status.status import StatusCommand
+from reqstool.common.enrichment.enricher import BUILT_IN_PRESETS
 from reqstool.common.utils import Utils
 from reqstool.common.validators.syntax_validator import JsonSchemaItem
 from reqstool.locations.git_location import GitLocation
@@ -293,6 +295,31 @@ class Command:
         status_source_subparsers = status_parser.add_subparsers(dest="source", required=True)
         self._add_subparsers_source(status_source_subparsers)
 
+        # command: enrich
+        enrich_parser = subparsers.add_parser(
+            "enrich",
+            help=(
+                "Enrich a document with requirement/SVC/MVR titles and descriptions. "
+                "Auto-detects dataset from .reqstool-ai.yaml if no source is given."
+            ),
+        )
+        enrich_parser.add_argument(
+            "--preset",
+            required=True,
+            choices=sorted(BUILT_IN_PRESETS),
+            help="Enrichment preset (e.g. openspec:spec, openspec:design)",
+        )
+        enrich_parser.add_argument(
+            "--input",
+            "-i",
+            metavar="FILE",
+            default=None,
+            help="Input file to enrich (default: stdin)",
+        )
+        self._add_argument_output(enrich_parser)
+        enrich_source_subparsers = enrich_parser.add_subparsers(dest="source", required=False)
+        self._add_subparsers_source(enrich_source_subparsers, include_report_options=False, include_filter_options=False)
+
         # command: lsp
         lsp_parser = subparsers.add_parser(
             "lsp", help="Start the Language Server Protocol server (requires reqstool[lsp])"
@@ -487,6 +514,42 @@ class Command:
             logging.fatal("reqstool MCP server crashed: %s", exc)
             sys.exit(1)
 
+    @Requirements("REQ_039")
+    def command_enrich(self, enrich_args: argparse.Namespace):
+        if getattr(enrich_args, "source", None) is None:
+            from pathlib import Path
+
+            from reqstool.common.reqstool_ai_config import CONFIG_FILENAME, find_config, resolve_system_path
+
+            config_path = find_config()
+            if config_path is None:
+                print(
+                    f"reqstool enrich: no {CONFIG_FILENAME} found from {Path.cwd()} upward; "
+                    f"either run from a project containing {CONFIG_FILENAME} or specify an explicit source "
+                    f"(e.g. `reqstool enrich --preset openspec:spec --input foo.md local -p <path>`).",
+                    file=sys.stderr,
+                )
+                sys.exit(2)
+            try:
+                resolved = resolve_system_path(config_path)
+            except ValueError as exc:
+                print(f"reqstool enrich: {exc}", file=sys.stderr)
+                sys.exit(2)
+            location: LocationInterface = LocalLocation(path=str(resolved))
+        else:
+            location = self._get_initial_source(enrich_args)
+
+        input_file = getattr(enrich_args, "input", None)
+        if input_file is None:
+            input_content = sys.stdin.read()
+        else:
+            with open(input_file, encoding="utf-8") as f:
+                input_content = f.read()
+
+        config = BUILT_IN_PRESETS[enrich_args.preset]
+        result = EnrichCommand(location=location, input_content=input_content, config=config)
+        enrich_args.output.write(result.result)
+
     def print_help(self):
         self.__parser.print_help(sys.stderr)
 
@@ -523,6 +586,8 @@ def main():  # noqa: C901
             command.command_lsp(lsp_args=args)
         elif args.command == "mcp":
             command.command_mcp(mcp_args=args)
+        elif args.command == "enrich":
+            command.command_enrich(enrich_args=args)
         else:
             command.print_help()
     except MissingRequirementsFileError as exc:

--- a/src/reqstool/command.py
+++ b/src/reqstool/command.py
@@ -318,7 +318,9 @@ class Command:
         )
         self._add_argument_output(enrich_parser)
         enrich_source_subparsers = enrich_parser.add_subparsers(dest="source", required=False)
-        self._add_subparsers_source(enrich_source_subparsers, include_report_options=False, include_filter_options=False)
+        self._add_subparsers_source(
+            enrich_source_subparsers, include_report_options=False, include_filter_options=False
+        )
 
         # command: lsp
         lsp_parser = subparsers.add_parser(

--- a/src/reqstool/commands/enrich/__init__.py
+++ b/src/reqstool/commands/enrich/__init__.py
@@ -1,0 +1,1 @@
+# Copyright © LFV

--- a/src/reqstool/commands/enrich/enrich.py
+++ b/src/reqstool/commands/enrich/enrich.py
@@ -1,0 +1,30 @@
+# Copyright © LFV
+
+from reqstool_python_decorators.decorators.decorators import Requirements
+
+from reqstool.common.enrichment.enricher import EnrichmentConfig, enrich_text
+from reqstool.common.validator_error_holder import ValidationErrorHolder
+from reqstool.common.validators.semantic_validator import SemanticValidator
+from reqstool.locations.location import LocationInterface
+from reqstool.storage.pipeline import build_database
+from reqstool.storage.requirements_repository import RequirementsRepository
+
+
+@Requirements("REQ_039")
+class EnrichCommand:
+    def __init__(self, location: LocationInterface, input_content: str, config: EnrichmentConfig):
+        self.__initial_location: LocationInterface = location
+        self.__input_content: str = input_content
+        self.__config: EnrichmentConfig = config
+        self.result: str = self.__run()
+
+    def __run(self) -> str:
+        with build_database(
+            location=self.__initial_location,
+            semantic_validator=SemanticValidator(validation_error_holder=ValidationErrorHolder()),
+        ) as (db, _):
+            repo = RequirementsRepository(db)
+            requirements = repo.get_all_requirements()
+            svcs = repo.get_all_svcs()
+            mvrs = repo.get_all_mvrs()
+        return enrich_text(self.__input_content, requirements, svcs, mvrs, self.__config)

--- a/src/reqstool/common/enrichment/__init__.py
+++ b/src/reqstool/common/enrichment/__init__.py
@@ -1,0 +1,1 @@
+# Copyright © LFV

--- a/src/reqstool/common/enrichment/enricher.py
+++ b/src/reqstool/common/enrichment/enricher.py
@@ -46,32 +46,34 @@ def _block_field(label: str, value: str) -> list:
     lines = value.splitlines()
     if not lines:
         return []
-    result = [f"> **{label}**: {lines[0]}"]
+    prefix = f"**{label}**: "
+    indent = " " * len(prefix)
+    result = [prefix + lines[0]]
     for line in lines[1:]:
-        result.append(f"> {line}" if line.strip() else ">")
+        result.append(indent + line if line.strip() else "")
     return result
 
 
 def _req_block_lines(req: RequirementData) -> list:
     lines = []
-    lines.append(f"> **Significance**: {_format_value(req.significance.value)}")
+    lines.append(f"**Significance**: {_format_value(req.significance.value)}")
     if req.description:
         lines.extend(_block_field("Description", req.description))
     if req.rationale:
         lines.extend(_block_field("Rationale", req.rationale))
     if req.categories:
         cats = ", ".join(sorted(_format_value(c.value) for c in req.categories))
-        lines.append(f"> **Categories**: {cats}")
+        lines.append(f"**Categories**: {cats}")
     if req.references:
         refs = []
         for ref_data in req.references:
             for uid in sorted(ref_data.requirement_ids, key=str):
                 refs.append(uid.id)
         if refs:
-            lines.append(f"> **References**: {', '.join(refs)}")
-    lines.append(f"> **Implementation**: {_format_value(req.implementation.value)}")
-    lines.append(f"> **Revision**: {req.revision}")
-    lines.append(f"> **Lifecycle**: {_format_value(req.lifecycle.state.value)}")
+            lines.append(f"**References**: {', '.join(refs)}")
+    lines.append(f"**Implementation**: {_format_value(req.implementation.value)}")
+    lines.append(f"**Revision**: {req.revision}")
+    lines.append(f"**Lifecycle**: {_format_value(req.lifecycle.state.value)}")
     return lines
 
 
@@ -79,14 +81,14 @@ def _svc_block_lines(svc: SVCData) -> list:
     lines = []
     if svc.description:
         lines.extend(_block_field("Description", svc.description))
-    lines.append(f"> **Verification**: {_format_value(svc.verification.value)}")
+    lines.append(f"**Verification**: {_format_value(svc.verification.value)}")
     if svc.instructions:
         lines.extend(_block_field("Instructions", svc.instructions))
     if svc.requirement_ids:
         reqs = ", ".join(uid.id for uid in svc.requirement_ids)
-        lines.append(f"> **Requirements**: {reqs}")
-    lines.append(f"> **Revision**: {svc.revision}")
-    lines.append(f"> **Lifecycle**: {_format_value(svc.lifecycle.state.value)}")
+        lines.append(f"**Requirements**: {reqs}")
+    lines.append(f"**Revision**: {svc.revision}")
+    lines.append(f"**Lifecycle**: {_format_value(svc.lifecycle.state.value)}")
     return lines
 
 
@@ -96,7 +98,7 @@ def _mvr_block_lines(mvr: MVRData) -> list:
         lines.extend(_block_field("Comment", mvr.comment))
     if mvr.svc_ids:
         svcs = ", ".join(uid.id for uid in mvr.svc_ids)
-        lines.append(f"> **SVCs**: {svcs}")
+        lines.append(f"**SVCs**: {svcs}")
     return lines
 
 

--- a/src/reqstool/common/enrichment/enricher.py
+++ b/src/reqstool/common/enrichment/enricher.py
@@ -204,6 +204,8 @@ def enrich_text(  # noqa: C901
                 if ":" in before and not after:
                     info = lookup[id_str]
                     output.append(stripped + f" — {info.inline_text}" + trailing)
+                    if info.block_lines:
+                        output.append("\n")  # blank line separates heading from block
                     for bl in info.block_lines:
                         output.append(bl + "  \n")  # trailing spaces = Markdown hard line break
                     last_enriched_id = id_str

--- a/src/reqstool/common/enrichment/enricher.py
+++ b/src/reqstool/common/enrichment/enricher.py
@@ -174,7 +174,7 @@ def enrich_text(  # noqa: C901
 
     for line in text.splitlines(keepends=True):
         stripped = line.rstrip("\n\r")
-        trailing = line[len(stripped):]  # noqa: E203
+        trailing = line[len(stripped) :]  # noqa: E203
 
         # Fenced block state machine
         if stripped.strip().startswith("```") or stripped.strip().startswith("~~~"):
@@ -200,7 +200,7 @@ def enrich_text(  # noqa: C901
                 last_match = matches[-1]
                 id_str = last_match.group(0)
                 before = stripped[: last_match.start()]  # noqa: E203
-                after = stripped[last_match.end():].rstrip()
+                after = stripped[last_match.end() :].rstrip()  # noqa: E203
                 if ":" in before and not after:
                     info = lookup[id_str]
                     output.append(stripped + f" — {info.inline_text}" + trailing)
@@ -222,7 +222,7 @@ def enrich_text(  # noqa: C901
             for m in reversed(matches):
                 id_str = m.group(0)
                 info = lookup[id_str]
-                result = result[: m.end()] + f" — {info.inline_text}" + result[m.end():]  # noqa: E203
+                result = result[: m.end()] + f" — {info.inline_text}" + result[m.end() :]  # noqa: E203
             output.append(result + trailing)
 
     return "".join(output)

--- a/src/reqstool/common/enrichment/enricher.py
+++ b/src/reqstool/common/enrichment/enricher.py
@@ -203,7 +203,7 @@ def enrich_text(  # noqa: C901
                     info = lookup[id_str]
                     output.append(stripped + f" — {info.inline_text}" + trailing)
                     for bl in info.block_lines:
-                        output.append(bl + "\n")
+                        output.append(bl + "  \n")  # trailing spaces = Markdown hard line break
                     last_enriched_id = id_str
                     continue
 

--- a/src/reqstool/common/enrichment/enricher.py
+++ b/src/reqstool/common/enrichment/enricher.py
@@ -1,0 +1,224 @@
+# Copyright © LFV
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+from reqstool.models.mvrs import MVRData
+from reqstool.models.requirements import RequirementData
+from reqstool.models.svcs import SVCData
+
+_UPPERCASE_VALUES = frozenset({"shall", "should", "may"})
+
+
+@dataclass(frozen=True)
+class EnrichmentConfig:
+    trigger: str  # 'colon-header' | 'inline'
+    title_only: bool  # True → skip block injection
+    drop_stubs: bool
+    skip_code_spans: bool
+
+
+BUILT_IN_PRESETS: dict[str, EnrichmentConfig] = {
+    "openspec:spec": EnrichmentConfig("colon-header", False, True, True),
+    "openspec:delta-spec": EnrichmentConfig("colon-header", False, True, True),
+    "openspec:design": EnrichmentConfig("inline", True, False, True),
+    "openspec:proposal": EnrichmentConfig("inline", True, False, True),
+    "openspec:tasks": EnrichmentConfig("inline", True, False, True),
+}
+
+
+@dataclass
+class _EntityInfo:
+    inline_text: str
+    block_lines: list
+
+
+def _format_value(value: str) -> str:
+    if value == "N/A":
+        return "N/A"
+    if value in _UPPERCASE_VALUES:
+        return value.upper()
+    return value.replace("-", " ").title()
+
+
+def _block_field(label: str, value: str) -> list:
+    lines = value.splitlines()
+    if not lines:
+        return []
+    result = [f"> **{label}**: {lines[0]}"]
+    for line in lines[1:]:
+        result.append(f"> {line}" if line.strip() else ">")
+    return result
+
+
+def _req_block_lines(req: RequirementData) -> list:
+    lines = []
+    lines.append(f"> **Significance**: {_format_value(req.significance.value)}")
+    if req.description:
+        lines.extend(_block_field("Description", req.description))
+    if req.rationale:
+        lines.extend(_block_field("Rationale", req.rationale))
+    if req.categories:
+        cats = ", ".join(sorted(_format_value(c.value) for c in req.categories))
+        lines.append(f"> **Categories**: {cats}")
+    if req.references:
+        refs = []
+        for ref_data in req.references:
+            for uid in sorted(ref_data.requirement_ids, key=str):
+                refs.append(uid.id)
+        if refs:
+            lines.append(f"> **References**: {', '.join(refs)}")
+    lines.append(f"> **Implementation**: {_format_value(req.implementation.value)}")
+    lines.append(f"> **Revision**: {req.revision}")
+    lines.append(f"> **Lifecycle**: {_format_value(req.lifecycle.state.value)}")
+    return lines
+
+
+def _svc_block_lines(svc: SVCData) -> list:
+    lines = []
+    if svc.description:
+        lines.extend(_block_field("Description", svc.description))
+    lines.append(f"> **Verification**: {_format_value(svc.verification.value)}")
+    if svc.instructions:
+        lines.extend(_block_field("Instructions", svc.instructions))
+    if svc.requirement_ids:
+        reqs = ", ".join(uid.id for uid in svc.requirement_ids)
+        lines.append(f"> **Requirements**: {reqs}")
+    lines.append(f"> **Revision**: {svc.revision}")
+    lines.append(f"> **Lifecycle**: {_format_value(svc.lifecycle.state.value)}")
+    return lines
+
+
+def _mvr_block_lines(mvr: MVRData) -> list:
+    lines = []
+    if mvr.comment:
+        lines.extend(_block_field("Comment", mvr.comment))
+    if mvr.svc_ids:
+        svcs = ", ".join(uid.id for uid in mvr.svc_ids)
+        lines.append(f"> **SVCs**: {svcs}")
+    return lines
+
+
+def _build_lookup(
+    requirements: dict,
+    svcs: dict,
+    mvrs: dict,
+    config: EnrichmentConfig,
+) -> dict:
+    lookup: dict[str, _EntityInfo] = {}
+    for urn_id, req in requirements.items():
+        block = [] if config.title_only else _req_block_lines(req)
+        lookup[urn_id.id] = _EntityInfo(inline_text=req.title, block_lines=block)
+    for urn_id, svc in svcs.items():
+        block = [] if config.title_only else _svc_block_lines(svc)
+        lookup[urn_id.id] = _EntityInfo(inline_text=svc.title, block_lines=block)
+    for urn_id, mvr in mvrs.items():
+        inline = "PASSED" if mvr.passed else "FAILED"
+        block = [] if config.title_only else _mvr_block_lines(mvr)
+        lookup[urn_id.id] = _EntityInfo(inline_text=inline, block_lines=block)
+    return lookup
+
+
+def _make_pattern(lookup: dict) -> re.Pattern:
+    if not lookup:
+        return re.compile(r"(?!)")
+    sorted_ids = sorted(lookup.keys(), key=len, reverse=True)
+    alternation = "|".join(re.escape(id_str) for id_str in sorted_ids)
+    return re.compile(r"\b(?:" + alternation + r")\b")
+
+
+def _in_backtick_span(line: str, pos: int) -> bool:
+    in_span = False
+    span_start = -1
+    i = 0
+    while i < len(line):
+        if line[i] == "`":
+            if not in_span:
+                span_start = i + 1
+                in_span = True
+            else:
+                if span_start <= pos < i:
+                    return True
+                in_span = False
+        i += 1
+    return False
+
+
+def _is_stub(line: str, id_str: str) -> bool:
+    return bool(
+        re.match(
+            r"^\s*The system SHALL (?:implement|pass)\s+" + re.escape(id_str) + r"\.?\s*$",
+            line,
+        )
+    )
+
+
+def enrich_text(  # noqa: C901
+    text: str,
+    requirements: dict,
+    svcs: dict,
+    mvrs: dict,
+    config: EnrichmentConfig,
+) -> str:
+    lookup = _build_lookup(requirements, svcs, mvrs, config)
+    if not lookup:
+        return text
+    pattern = _make_pattern(lookup)
+
+    output = []
+    in_fenced_block = False
+    last_enriched_id: Optional[str] = None
+
+    for line in text.splitlines(keepends=True):
+        stripped = line.rstrip("\n\r")
+        trailing = line[len(stripped):]  # noqa: E203
+
+        # Fenced block state machine
+        if stripped.strip().startswith("```") or stripped.strip().startswith("~~~"):
+            in_fenced_block = not in_fenced_block
+            output.append(line)
+            last_enriched_id = None
+            continue
+
+        if in_fenced_block:
+            output.append(line)
+            continue
+
+        if config.trigger == "colon-header":
+            # Drop stub on the line immediately following an enriched header
+            if last_enriched_id is not None:
+                if _is_stub(stripped, last_enriched_id):
+                    last_enriched_id = None
+                    continue
+                last_enriched_id = None
+
+            matches = [m for m in pattern.finditer(stripped) if not _in_backtick_span(stripped, m.start())]
+            if matches:
+                last_match = matches[-1]
+                id_str = last_match.group(0)
+                before = stripped[: last_match.start()]  # noqa: E203
+                after = stripped[last_match.end():].rstrip()
+                if ":" in before and not after:
+                    info = lookup[id_str]
+                    output.append(stripped + f" — {info.inline_text}" + trailing)
+                    for bl in info.block_lines:
+                        output.append(bl + "\n")
+                    last_enriched_id = id_str
+                    continue
+
+            output.append(line)
+
+        else:  # inline
+            matches = [m for m in pattern.finditer(stripped) if not _in_backtick_span(stripped, m.start())]
+            if not matches:
+                output.append(line)
+                continue
+            result = stripped
+            for m in reversed(matches):
+                id_str = m.group(0)
+                info = lookup[id_str]
+                result = result[: m.end()] + f" — {info.inline_text}" + result[m.end():]  # noqa: E203
+            output.append(result + trailing)
+
+    return "".join(output)

--- a/src/reqstool/common/reqstool_ai_config.py
+++ b/src/reqstool/common/reqstool_ai_config.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import Optional
 
-import yaml
+from ruamel.yaml import YAML as _YAML
 
 CONFIG_FILENAME = ".reqstool-ai.yaml"
 
@@ -26,8 +26,9 @@ def resolve_system_path(config_path: Path) -> Path:
 
     Raises ValueError if `system` or `system.path` is missing or not a string.
     """
+    yaml = _YAML()
     with open(config_path) as f:
-        data = yaml.safe_load(f) or {}
+        data = yaml.load(f) or {}
 
     system = data.get("system")
     if not isinstance(system, dict):

--- a/src/reqstool/mcp/server.py
+++ b/src/reqstool/mcp/server.py
@@ -4,6 +4,7 @@
 import logging
 
 from reqstool.common.project_session import ProjectSession
+from reqstool.common.enrichment.enricher import BUILT_IN_PRESETS, enrich_text
 from reqstool.common.queries.details import (
     get_mvr_details,
     get_requirement_details,
@@ -129,6 +130,21 @@ def start_server(location: LocationInterface) -> None:  # noqa: C901
         if result is None:
             raise ValueError(f"URN {urn!r} not found")
         return result
+
+    @mcp.tool()
+    def enrich_document(content: str, preset: str) -> str:
+        """Enrich an OpenSpec document by resolving requirement/SVC/MVR IDs.
+
+        Injects titles and further fields next to each known ID according to the
+        named preset. Both arguments are required.
+
+        Presets: openspec:spec, openspec:delta-spec, openspec:design,
+                 openspec:proposal, openspec:tasks
+        """
+        if preset not in BUILT_IN_PRESETS:
+            raise ValueError(f"Unknown preset {preset!r}. Valid: {sorted(BUILT_IN_PRESETS)}")
+        config = BUILT_IN_PRESETS[preset]
+        return enrich_text(content, repo.get_all_requirements(), repo.get_all_svcs(), repo.get_all_mvrs(), config)
 
     try:
         mcp.run()

--- a/tests/resources/enrich/inline_code_spans/expected.md
+++ b/tests/resources/enrich/inline_code_spans/expected.md
@@ -1,0 +1,7 @@
+Use `REQ_101` annotation.
+
+```java
+@Requirements({"REQ_101"})
+```
+
+Regular REQ_101 — Title REQ_101 mention.

--- a/tests/resources/enrich/inline_code_spans/input.md
+++ b/tests/resources/enrich/inline_code_spans/input.md
@@ -1,0 +1,7 @@
+Use `REQ_101` annotation.
+
+```java
+@Requirements({"REQ_101"})
+```
+
+Regular REQ_101 mention.

--- a/tests/resources/enrich/inline_title_only/expected.md
+++ b/tests/resources/enrich/inline_title_only/expected.md
@@ -1,0 +1,3 @@
+This implements REQ_101 — Title REQ_101 and verifies SVC_201 — Some Title SVC_201.
+
+Another mention of REQ_101 — Title REQ_101 later.

--- a/tests/resources/enrich/inline_title_only/input.md
+++ b/tests/resources/enrich/inline_title_only/input.md
@@ -1,0 +1,3 @@
+This implements REQ_101 and verifies SVC_201.
+
+Another mention of REQ_101 later.

--- a/tests/resources/enrich/mvr/expected.md
+++ b/tests/resources/enrich/mvr/expected.md
@@ -1,6 +1,6 @@
 #### Result: MVR_201 — PASSED
-> **SVCs**: SVC_201  
+**SVCs**: SVC_201  
 
 #### Result: MVR_202 — FAILED
-> **Comment**: Failed due...  
-> **SVCs**: SVC_202  
+**Comment**: Failed due...  
+**SVCs**: SVC_202  

--- a/tests/resources/enrich/mvr/expected.md
+++ b/tests/resources/enrich/mvr/expected.md
@@ -1,6 +1,8 @@
 #### Result: MVR_201 — PASSED
+
 **SVCs**: SVC_201  
 
 #### Result: MVR_202 — FAILED
+
 **Comment**: Failed due...  
 **SVCs**: SVC_202  

--- a/tests/resources/enrich/mvr/expected.md
+++ b/tests/resources/enrich/mvr/expected.md
@@ -1,0 +1,6 @@
+#### Result: MVR_201 — PASSED
+> **SVCs**: SVC_201
+
+#### Result: MVR_202 — FAILED
+> **Comment**: Failed due...
+> **SVCs**: SVC_202

--- a/tests/resources/enrich/mvr/expected.md
+++ b/tests/resources/enrich/mvr/expected.md
@@ -1,6 +1,6 @@
 #### Result: MVR_201 — PASSED
-> **SVCs**: SVC_201
+> **SVCs**: SVC_201  
 
 #### Result: MVR_202 — FAILED
-> **Comment**: Failed due...
-> **SVCs**: SVC_202
+> **Comment**: Failed due...  
+> **SVCs**: SVC_202  

--- a/tests/resources/enrich/mvr/input.md
+++ b/tests/resources/enrich/mvr/input.md
@@ -1,0 +1,5 @@
+#### Result: MVR_201
+The system SHALL pass MVR_201.
+
+#### Result: MVR_202
+The system SHALL pass MVR_202.

--- a/tests/resources/enrich/no_ids/expected.md
+++ b/tests/resources/enrich/no_ids/expected.md
@@ -1,0 +1,3 @@
+This is a document with no requirement IDs.
+
+Just plain text here.

--- a/tests/resources/enrich/no_ids/input.md
+++ b/tests/resources/enrich/no_ids/input.md
@@ -1,0 +1,3 @@
+This is a document with no requirement IDs.
+
+Just plain text here.

--- a/tests/resources/enrich/spec_all_fields/expected.md
+++ b/tests/resources/enrich/spec_all_fields/expected.md
@@ -1,4 +1,5 @@
 ### Requirement: REQ_101 — Title REQ_101
+
 **Significance**: MAY  
 **Description**: Description REQ_101  
 **Rationale**: Rationale REQ_001  
@@ -8,6 +9,7 @@
 **Lifecycle**: Effective  
 
 #### Scenario: SVC_201 — Some Title SVC_201
+
 **Description**: Some Description SVC_201  
 **Verification**: Manual Test  
 **Instructions**: Some instructions  

--- a/tests/resources/enrich/spec_all_fields/expected.md
+++ b/tests/resources/enrich/spec_all_fields/expected.md
@@ -1,16 +1,16 @@
 ### Requirement: REQ_101 — Title REQ_101
-> **Significance**: MAY
-> **Description**: Description REQ_101
-> **Rationale**: Rationale REQ_001
-> **Categories**: Functional Suitability, Maintainability
-> **Implementation**: In Code
-> **Revision**: 0.0.1
-> **Lifecycle**: Effective
+> **Significance**: MAY  
+> **Description**: Description REQ_101  
+> **Rationale**: Rationale REQ_001  
+> **Categories**: Functional Suitability, Maintainability  
+> **Implementation**: In Code  
+> **Revision**: 0.0.1  
+> **Lifecycle**: Effective  
 
 #### Scenario: SVC_201 — Some Title SVC_201
-> **Description**: Some Description SVC_201
-> **Verification**: Manual Test
-> **Instructions**: Some instructions
-> **Requirements**: REQ_201
-> **Revision**: 0.0.2
-> **Lifecycle**: Effective
+> **Description**: Some Description SVC_201  
+> **Verification**: Manual Test  
+> **Instructions**: Some instructions  
+> **Requirements**: REQ_201  
+> **Revision**: 0.0.2  
+> **Lifecycle**: Effective  

--- a/tests/resources/enrich/spec_all_fields/expected.md
+++ b/tests/resources/enrich/spec_all_fields/expected.md
@@ -1,0 +1,16 @@
+### Requirement: REQ_101 — Title REQ_101
+> **Significance**: MAY
+> **Description**: Description REQ_101
+> **Rationale**: Rationale REQ_001
+> **Categories**: Functional Suitability, Maintainability
+> **Implementation**: In Code
+> **Revision**: 0.0.1
+> **Lifecycle**: Effective
+
+#### Scenario: SVC_201 — Some Title SVC_201
+> **Description**: Some Description SVC_201
+> **Verification**: Manual Test
+> **Instructions**: Some instructions
+> **Requirements**: REQ_201
+> **Revision**: 0.0.2
+> **Lifecycle**: Effective

--- a/tests/resources/enrich/spec_all_fields/expected.md
+++ b/tests/resources/enrich/spec_all_fields/expected.md
@@ -1,16 +1,16 @@
 ### Requirement: REQ_101 — Title REQ_101
-> **Significance**: MAY  
-> **Description**: Description REQ_101  
-> **Rationale**: Rationale REQ_001  
-> **Categories**: Functional Suitability, Maintainability  
-> **Implementation**: In Code  
-> **Revision**: 0.0.1  
-> **Lifecycle**: Effective  
+**Significance**: MAY  
+**Description**: Description REQ_101  
+**Rationale**: Rationale REQ_001  
+**Categories**: Functional Suitability, Maintainability  
+**Implementation**: In Code  
+**Revision**: 0.0.1  
+**Lifecycle**: Effective  
 
 #### Scenario: SVC_201 — Some Title SVC_201
-> **Description**: Some Description SVC_201  
-> **Verification**: Manual Test  
-> **Instructions**: Some instructions  
-> **Requirements**: REQ_201  
-> **Revision**: 0.0.2  
-> **Lifecycle**: Effective  
+**Description**: Some Description SVC_201  
+**Verification**: Manual Test  
+**Instructions**: Some instructions  
+**Requirements**: REQ_201  
+**Revision**: 0.0.2  
+**Lifecycle**: Effective  

--- a/tests/resources/enrich/spec_all_fields/input.md
+++ b/tests/resources/enrich/spec_all_fields/input.md
@@ -1,0 +1,5 @@
+### Requirement: REQ_101
+The system SHALL implement REQ_101.
+
+#### Scenario: SVC_201
+The system SHALL pass SVC_201.

--- a/tests/resources/enrich/spec_no_description/expected.md
+++ b/tests/resources/enrich/spec_no_description/expected.md
@@ -1,0 +1,5 @@
+#### Scenario: SVC_101 — Some Title SVC_101
+> **Verification**: Automated Test
+> **Requirements**: REQ_101
+> **Revision**: 0.0.1
+> **Lifecycle**: Effective

--- a/tests/resources/enrich/spec_no_description/expected.md
+++ b/tests/resources/enrich/spec_no_description/expected.md
@@ -1,5 +1,5 @@
 #### Scenario: SVC_101 — Some Title SVC_101
-> **Verification**: Automated Test  
-> **Requirements**: REQ_101  
-> **Revision**: 0.0.1  
-> **Lifecycle**: Effective  
+**Verification**: Automated Test  
+**Requirements**: REQ_101  
+**Revision**: 0.0.1  
+**Lifecycle**: Effective  

--- a/tests/resources/enrich/spec_no_description/expected.md
+++ b/tests/resources/enrich/spec_no_description/expected.md
@@ -1,4 +1,5 @@
 #### Scenario: SVC_101 — Some Title SVC_101
+
 **Verification**: Automated Test  
 **Requirements**: REQ_101  
 **Revision**: 0.0.1  

--- a/tests/resources/enrich/spec_no_description/expected.md
+++ b/tests/resources/enrich/spec_no_description/expected.md
@@ -1,5 +1,5 @@
 #### Scenario: SVC_101 — Some Title SVC_101
-> **Verification**: Automated Test
-> **Requirements**: REQ_101
-> **Revision**: 0.0.1
-> **Lifecycle**: Effective
+> **Verification**: Automated Test  
+> **Requirements**: REQ_101  
+> **Revision**: 0.0.1  
+> **Lifecycle**: Effective  

--- a/tests/resources/enrich/spec_no_description/input.md
+++ b/tests/resources/enrich/spec_no_description/input.md
@@ -1,0 +1,2 @@
+#### Scenario: SVC_101
+The system SHALL pass SVC_101.

--- a/tests/unit/reqstool/commands/enrich/__init__.py
+++ b/tests/unit/reqstool/commands/enrich/__init__.py
@@ -1,0 +1,1 @@
+# Copyright © LFV

--- a/tests/unit/reqstool/commands/enrich/test_enrich.py
+++ b/tests/unit/reqstool/commands/enrich/test_enrich.py
@@ -1,0 +1,65 @@
+# Copyright © LFV
+
+from pathlib import Path
+
+import pytest
+
+from reqstool_python_decorators.decorators.decorators import SVCs
+
+from reqstool.commands.enrich.enrich import EnrichCommand
+from reqstool.common.enrichment.enricher import BUILT_IN_PRESETS
+from reqstool.locations.local_location import LocalLocation
+
+_ENRICH_RESOURCES = Path(__file__).parents[4] / "resources" / "enrich"
+
+
+def _load(fixture: str) -> tuple[str, str]:
+    base = _ENRICH_RESOURCES / fixture
+    return (base / "input.md").read_text(), (base / "expected.md").read_text()
+
+
+@pytest.fixture()
+def ms101(local_testdata_resources_rootdir_w_path):
+    return LocalLocation(path=local_testdata_resources_rootdir_w_path("test_basic/baseline/ms-101"))
+
+
+@SVCs("SVC_039")
+def test_spec_all_fields(ms101):
+    input_content, expected = _load("spec_all_fields")
+    result = EnrichCommand(location=ms101, input_content=input_content, config=BUILT_IN_PRESETS["openspec:spec"])
+    assert result.result == expected
+
+
+@SVCs("SVC_039")
+def test_spec_no_description(ms101):
+    input_content, expected = _load("spec_no_description")
+    result = EnrichCommand(location=ms101, input_content=input_content, config=BUILT_IN_PRESETS["openspec:spec"])
+    assert result.result == expected
+
+
+@SVCs("SVC_039")
+def test_inline_title_only(ms101):
+    input_content, expected = _load("inline_title_only")
+    result = EnrichCommand(location=ms101, input_content=input_content, config=BUILT_IN_PRESETS["openspec:design"])
+    assert result.result == expected
+
+
+@SVCs("SVC_039")
+def test_inline_code_spans_skipped(ms101):
+    input_content, expected = _load("inline_code_spans")
+    result = EnrichCommand(location=ms101, input_content=input_content, config=BUILT_IN_PRESETS["openspec:design"])
+    assert result.result == expected
+
+
+@SVCs("SVC_039")
+def test_no_ids_passthrough(ms101):
+    input_content, expected = _load("no_ids")
+    result = EnrichCommand(location=ms101, input_content=input_content, config=BUILT_IN_PRESETS["openspec:spec"])
+    assert result.result == expected
+
+
+@SVCs("SVC_039")
+def test_mvr_enrichment(ms101):
+    input_content, expected = _load("mvr")
+    result = EnrichCommand(location=ms101, input_content=input_content, config=BUILT_IN_PRESETS["openspec:spec"])
+    assert result.result == expected

--- a/tests/unit/reqstool/common/__init__.py
+++ b/tests/unit/reqstool/common/__init__.py
@@ -1,0 +1,1 @@
+# Copyright © LFV

--- a/tests/unit/reqstool/common/enrichment/__init__.py
+++ b/tests/unit/reqstool/common/enrichment/__init__.py
@@ -1,0 +1,1 @@
+# Copyright © LFV

--- a/tests/unit/reqstool/common/enrichment/test_enricher.py
+++ b/tests/unit/reqstool/common/enrichment/test_enricher.py
@@ -1,0 +1,144 @@
+# Copyright © LFV
+
+from reqstool.common.enrichment.enricher import (
+    BUILT_IN_PRESETS,
+    _format_value,
+    _in_backtick_span,
+    _is_stub,
+    _make_pattern,
+    enrich_text,
+)
+
+
+# ---------------------------------------------------------------------------
+# _format_value
+# ---------------------------------------------------------------------------
+
+
+def test_format_value_significance_shall():
+    assert _format_value("shall") == "SHALL"
+
+
+def test_format_value_significance_should():
+    assert _format_value("should") == "SHOULD"
+
+
+def test_format_value_significance_may():
+    assert _format_value("may") == "MAY"
+
+
+def test_format_value_na():
+    assert _format_value("N/A") == "N/A"
+
+
+def test_format_value_hyphenated():
+    assert _format_value("automated-test") == "Automated Test"
+    assert _format_value("manual-test") == "Manual Test"
+    assert _format_value("in-code") == "In Code"
+    assert _format_value("functional-suitability") == "Functional Suitability"
+
+
+def test_format_value_single_word():
+    assert _format_value("effective") == "Effective"
+    assert _format_value("security") == "Security"
+    assert _format_value("maintainability") == "Maintainability"
+
+
+# ---------------------------------------------------------------------------
+# _in_backtick_span
+# ---------------------------------------------------------------------------
+
+
+def test_in_backtick_span_inside():
+    line = "Use `REQ_101` here"
+    pos = line.index("REQ_101")
+    assert _in_backtick_span(line, pos) is True
+
+
+def test_in_backtick_span_outside():
+    line = "Use `something` and REQ_101"
+    pos = line.index("REQ_101")
+    assert _in_backtick_span(line, pos) is False
+
+
+def test_in_backtick_span_no_backticks():
+    line = "Just REQ_101 here"
+    pos = line.index("REQ_101")
+    assert _in_backtick_span(line, pos) is False
+
+
+# ---------------------------------------------------------------------------
+# _is_stub
+# ---------------------------------------------------------------------------
+
+
+def test_is_stub_implement():
+    assert _is_stub("The system SHALL implement REQ_101.", "REQ_101") is True
+
+
+def test_is_stub_pass():
+    assert _is_stub("The system SHALL pass SVC_101.", "SVC_101") is True
+
+
+def test_is_stub_wrong_id():
+    assert _is_stub("The system SHALL implement REQ_101.", "REQ_102") is False
+
+
+def test_is_stub_not_a_stub():
+    assert _is_stub("### Requirement: REQ_101", "REQ_101") is False
+
+
+def test_is_stub_without_period():
+    assert _is_stub("The system SHALL implement REQ_101", "REQ_101") is True
+
+
+# ---------------------------------------------------------------------------
+# _make_pattern
+# ---------------------------------------------------------------------------
+
+
+def test_make_pattern_empty():
+    pattern = _make_pattern({})
+    assert pattern.search("REQ_101") is None
+
+
+def test_make_pattern_matches():
+    from reqstool.common.enrichment.enricher import _EntityInfo
+
+    lookup = {"REQ_101": _EntityInfo("Title", []), "SVC_101": _EntityInfo("SVC Title", [])}
+    pattern = _make_pattern(lookup)
+    assert pattern.search("REQ_101") is not None
+    assert pattern.search("SVC_101") is not None
+    assert pattern.search("UNKNOWN") is None
+
+
+def test_make_pattern_word_boundary():
+    from reqstool.common.enrichment.enricher import _EntityInfo
+
+    lookup = {"REQ_101": _EntityInfo("Title", [])}
+    pattern = _make_pattern(lookup)
+    assert pattern.search("REQ_1010") is None
+    assert pattern.search("PREFIX_REQ_101") is None
+
+
+# ---------------------------------------------------------------------------
+# enrich_text — pure (no DB, minimal mock data)
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_text_empty_text():
+    result = enrich_text("", {}, {}, {}, BUILT_IN_PRESETS["openspec:spec"])
+    assert result == ""
+
+
+def test_enrich_text_no_ids_passthrough():
+    text = "Just plain text.\nNo IDs here.\n"
+    result = enrich_text(text, {}, {}, {}, BUILT_IN_PRESETS["openspec:spec"])
+    assert result == text
+
+
+def test_enrich_text_fenced_block_skipped():
+    text = "```\nREQ_101\n```\n"
+    result = enrich_text(text, {}, {}, {}, BUILT_IN_PRESETS["openspec:design"])
+    assert "—" not in result
+    assert result == text


### PR DESCRIPTION
## Summary

- Implements `reqstool enrich` (one-shot mode) per issue #352
- New command scans input text for known requirement/SVC/MVR IDs and injects titles + metadata inline using built-in presets (`openspec:spec`, `openspec:design`, `openspec:proposal`, `openspec:tasks`, `openspec:delta-spec`)
- Auto-detects the reqstool dataset from `.reqstool-ai.yaml` (same walk-up mechanism as `reqstool mcp`); explicit source sub-commands (`local`, `git`, `maven`, `pypi`) also supported
- Adds `enrich_document(content, preset)` MCP tool to the existing MCP server
- Shared enrichment logic in `src/reqstool/common/enrichment/enricher.py` used by both CLI and MCP

## Implementation plan

See [PLAN.md](PLAN.md) for the full design, including algorithm details, preset definitions, and the test strategy.

## Scope

- [x] `reqstool enrich --preset <name> [--input <file>] [-o <file>] [source]`  — one-shot mode
- [x] `enrich_document(content, preset)` MCP tool
- [ ] `reqstool enrich --stdio`  — daemon mode (follow-up, out of scope for this PR)

## Closes

Closes #352

## Test plan

- [x] New unit tests under `tests/unit/reqstool/commands/enrich/` and `tests/unit/reqstool/common/enrichment/` covering pure helpers and integration against the `test_basic/baseline/ms-101` fixture (26 tests)
- [x] Full unit suite passes with no regressions (`hatch run dev:pytest tests/unit` — 604 passed)
- [x] Manual smoke test against atunko project via openspecui hook — SVC enrichment working correctly