### PR TITLE
fix(config): use ruamel.yaml instead of pyyaml in reqstool_ai_config

### DIFF
--- a/src/reqstool/common/reqstool_ai_config.py
+++ b/src/reqstool/common/reqstool_ai_config.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import Optional
 
-import yaml
+from ruamel.yaml import YAML as _YAML
 
 CONFIG_FILENAME = ".reqstool-ai.yaml"
 
@@ -26,8 +26,9 @@ def resolve_system_path(config_path: Path) -> Path:
 
     Raises ValueError if `system` or `system.path` is missing or not a string.
     """
+    yaml = _YAML()
     with open(config_path) as f:
-        data = yaml.safe_load(f) or {}
+        data = yaml.load(f) or {}
 
     system = data.get("system")
     if not isinstance(system, dict):


### PR DESCRIPTION
## Problem

`reqstool_ai_config.py` imported `yaml` via `import yaml` (pyyaml API), but `pyyaml` is not a declared dependency — `ruamel.yaml==0.19.1` is. This caused a `ModuleNotFoundError: No module named 'yaml'` at runtime when auto-detecting `.reqstool-ai.yaml`.

## Fix

Replace `import yaml` / `yaml.safe_load()` with `ruamel.yaml`'s `YAML` loader.