### PR TITLE
fix(tmpdir): replace hardcoded 'can_we_use_urn_here' suffix with location-based identifier

### DIFF
--- a/src/reqstool/common/utils.py
+++ b/src/reqstool/common/utils.py
@@ -213,6 +213,9 @@ class TempDirectoryManager:
 
     def get_suffix_path(self, suffix: str) -> Path:
         new_path = Path(self._tmpdir.name) / str(self._count) / suffix
+        root = Path(self._tmpdir.name).resolve()
+        if not new_path.resolve().is_relative_to(root):
+            raise ValueError(f"suffix {suffix!r} would escape the managed temp directory")
         new_path.mkdir(parents=True, exist_ok=True)
         self._count += 1
         return new_path

--- a/src/reqstool/locations/git_location.py
+++ b/src/reqstool/locations/git_location.py
@@ -7,7 +7,7 @@ from typing import Optional
 from pygit2 import RemoteCallbacks, UserPass, clone_repository
 from reqstool_python_decorators.decorators.decorators import Requirements
 
-from reqstool.locations.location import LocationInterface
+from reqstool.locations.location import LocationInterface, make_safe_tmpdir_suffix
 
 
 @Requirements("REQ_002")
@@ -16,6 +16,15 @@ class GitLocation(LocationInterface):
     branch: str
     env_token: Optional[str] = None
     path: str = ""
+
+    def tmpdir_key(self) -> str:
+        from urllib.parse import urlparse, urlunparse
+
+        parsed = urlparse(self.url)
+        if parsed.username or parsed.password:
+            host = parsed.hostname or ""
+            parsed = parsed._replace(netloc=host + (f":{parsed.port}" if parsed.port else ""))
+        return make_safe_tmpdir_suffix("git", urlunparse(parsed))
 
     def _make_available_on_localdisk(self, dst_path: str) -> str:
         api_token = os.getenv(self.env_token) if self.env_token else None

--- a/src/reqstool/locations/local_location.py
+++ b/src/reqstool/locations/local_location.py
@@ -4,12 +4,15 @@ import os
 
 from reqstool_python_decorators.decorators.decorators import Requirements
 
-from reqstool.locations.location import LocationInterface
+from reqstool.locations.location import LocationInterface, make_safe_tmpdir_suffix
 
 
 @Requirements("REQ_001")
 class LocalLocation(LocationInterface):
     path: str
+
+    def tmpdir_key(self) -> str:
+        return make_safe_tmpdir_suffix("local", f"file://{os.path.abspath(self.path)}")
 
     def _make_available_on_localdisk(self, dst_path: str):
         # dst_directory already exists but should a symlimk, remove

--- a/src/reqstool/locations/local_maven_location.py
+++ b/src/reqstool/locations/local_maven_location.py
@@ -1,11 +1,16 @@
 # Copyright © LFV
 
+import os
+
 from reqstool.common.utils import Utils
-from reqstool.locations.location import LocationInterface
+from reqstool.locations.location import LocationInterface, make_safe_tmpdir_suffix
 
 
 class LocalMavenLocation(LocationInterface):
     path: str  # path to a local Maven ZIP artifact (.zip)
+
+    def tmpdir_key(self) -> str:
+        return make_safe_tmpdir_suffix("local_maven", f"file://{os.path.abspath(self.path)}")
 
     def _make_available_on_localdisk(self, dst_path: str) -> str:
         return Utils.extract_zip(self.path, dst_path)

--- a/src/reqstool/locations/local_pypi_location.py
+++ b/src/reqstool/locations/local_pypi_location.py
@@ -1,11 +1,16 @@
 # Copyright © LFV
 
+import os
+
 from reqstool.common.utils import Utils
-from reqstool.locations.location import LocationInterface
+from reqstool.locations.location import LocationInterface, make_safe_tmpdir_suffix
 
 
 class LocalPypiLocation(LocationInterface):
     path: str  # path to a local PyPI sdist tarball (.tar.gz)
+
+    def tmpdir_key(self) -> str:
+        return make_safe_tmpdir_suffix("local_pypi", f"file://{os.path.abspath(self.path)}")
 
     def _make_available_on_localdisk(self, dst_path: str) -> str:
         return Utils.extract_targz(self.path, dst_path)

--- a/src/reqstool/locations/location.py
+++ b/src/reqstool/locations/location.py
@@ -1,9 +1,13 @@
 # Copyright © LFV
 
+import re
 from abc import ABC, abstractmethod
 from enum import Enum, unique
 
 from pydantic import BaseModel, ConfigDict
+
+_SUFFIX_MAX_LEN = 80
+_UNSAFE_PATH_CHARS = re.compile(r"[^a-zA-Z0-9._-]")
 
 
 @unique
@@ -14,9 +18,19 @@ class LOCATIONTYPES(Enum):
     PYPI = "pypi"
 
 
+def make_safe_tmpdir_suffix(prefix: str, uri: str) -> str:
+    """Return a filesystem-safe temp-dir suffix: '{prefix}_{sanitized_uri}' capped at _SUFFIX_MAX_LEN chars."""
+    sanitized = re.sub(r"\.{2,}", "_", _UNSAFE_PATH_CHARS.sub("_", uri))
+    return f"{prefix}_{sanitized}"[:_SUFFIX_MAX_LEN]
+
+
 class LocationInterface(BaseModel, ABC):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @abstractmethod
     def _make_available_on_localdisk(self, dst_path: str) -> str:
         pass
+
+    @abstractmethod
+    def tmpdir_key(self) -> str:
+        """Return a short, filesystem-safe string identifying this location for use as a temp-dir suffix."""

--- a/src/reqstool/locations/maven_location.py
+++ b/src/reqstool/locations/maven_location.py
@@ -9,7 +9,7 @@ from reqstool_python_decorators.decorators.decorators import Requirements
 
 from reqstool.common.exceptions import ArtifactDownloadError, ArtifactExtractionError
 from reqstool.common.utils import Utils
-from reqstool.locations.location import LocationInterface
+from reqstool.locations.location import LocationInterface, make_safe_tmpdir_suffix
 
 
 @Requirements("REQ_003", "REQ_017")
@@ -20,6 +20,9 @@ class MavenLocation(LocationInterface):
     version: str
     classifier: str = "reqstool"
     env_token: Optional[str] = None
+
+    def tmpdir_key(self) -> str:
+        return make_safe_tmpdir_suffix("maven", f"{self.group_id}:{self.artifact_id}:{self.version}")
 
     def _make_available_on_localdisk(self, dst_path: str):
         token = os.getenv(self.env_token) if self.env_token else None

--- a/src/reqstool/locations/pypi_location.py
+++ b/src/reqstool/locations/pypi_location.py
@@ -9,7 +9,7 @@ import requests
 from bs4 import BeautifulSoup
 from reqstool.common.exceptions import ArtifactDownloadError, ArtifactExtractionError
 from reqstool.common.utils import Utils
-from reqstool.locations.location import LocationInterface
+from reqstool.locations.location import LocationInterface, make_safe_tmpdir_suffix
 
 
 class PypiLocation(LocationInterface):
@@ -21,6 +21,9 @@ class PypiLocation(LocationInterface):
     @staticmethod
     def normalize_pypi_package_name(package_name):
         return re.sub(r"[-_.]+", "-", package_name).lower()
+
+    def tmpdir_key(self) -> str:
+        return make_safe_tmpdir_suffix("pypi", f"{self.package}=={self.version}")
 
     def _make_available_on_localdisk(self, dst_path: str):
         """

--- a/src/reqstool/model_generators/combined_raw_datasets_generator.py
+++ b/src/reqstool/model_generators/combined_raw_datasets_generator.py
@@ -4,9 +4,6 @@ import logging
 import os
 import re
 from collections import defaultdict
-
-_SUFFIX_MAX_LEN = 80
-_UNSAFE_PATH_CHARS = re.compile(r"[^a-zA-Z0-9._-]")
 from typing import Dict, List, Optional, Set, Tuple
 
 from reqstool_python_decorators.decorators.decorators import Requirements
@@ -32,6 +29,9 @@ from reqstool.models.svcs import SVCsData
 from reqstool.models.test_data import TestsData
 from reqstool.requirements_indata.requirements_indata import RequirementsIndata
 from reqstool.storage.database import RequirementsDatabase
+
+_SUFFIX_MAX_LEN = 80
+_UNSAFE_PATH_CHARS = re.compile(r"[^a-zA-Z0-9._-]")
 
 
 @Requirements("REQ_005", "REQ_006", "REQ_007")

--- a/src/reqstool/model_generators/combined_raw_datasets_generator.py
+++ b/src/reqstool/model_generators/combined_raw_datasets_generator.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-import re
 from collections import defaultdict
 from typing import Dict, List, Optional, Set, Tuple
 
@@ -29,9 +28,6 @@ from reqstool.models.svcs import SVCsData
 from reqstool.models.test_data import TestsData
 from reqstool.requirements_indata.requirements_indata import RequirementsIndata
 from reqstool.storage.database import RequirementsDatabase
-
-_SUFFIX_MAX_LEN = 80
-_UNSAFE_PATH_CHARS = re.compile(r"[^a-zA-Z0-9._-]")
 
 
 @Requirements("REQ_005", "REQ_006", "REQ_007")
@@ -257,11 +253,7 @@ class CombinedRawDatasetsGenerator:
         mvrs_data = None
         automated_tests = None
 
-        location_type, location_uri = self.__extract_location_provenance(current_location_handler.current)
-        type_prefix = location_type or "unknown"
-        sanitized_uri = re.sub(r"\.{2,}", "_", _UNSAFE_PATH_CHARS.sub("_", location_uri or ""))
-        safe_suffix = f"{type_prefix}_{sanitized_uri}"[:_SUFFIX_MAX_LEN]
-        tmp_path = self._tmpdir_manager.get_suffix_path(safe_suffix).absolute()
+        tmp_path = self._tmpdir_manager.get_suffix_path(current_location_handler.current.tmpdir_key()).absolute()
 
         actual_tmp_path = current_location_handler.make_available_on_localdisk(dst_path=tmp_path)
 
@@ -288,6 +280,8 @@ class CombinedRawDatasetsGenerator:
             actual_tmp_path, requirements_indata, rmg
         )
 
+        location_type, location_uri = self.__extract_location_provenance(current_location_handler.current)
+
         # Capture resolved file paths for LocalLocation only
         source_paths = self.__extract_source_paths(current_location_handler.current, requirements_indata)
 
@@ -306,9 +300,7 @@ class CombinedRawDatasetsGenerator:
 
     @staticmethod
     def __extract_location_provenance(location: LocationInterface) -> tuple:
-        """Extract location_type and location_uri from a resolved location."""
-        from urllib.parse import urlparse, urlunparse
-
+        """Extract location_type and location_uri for RawDataset metadata."""
         from reqstool.locations.git_location import GitLocation
         from reqstool.locations.local_maven_location import LocalMavenLocation
         from reqstool.locations.local_pypi_location import LocalPypiLocation
@@ -318,10 +310,7 @@ class CombinedRawDatasetsGenerator:
         if isinstance(location, LocalLocation):
             return "local", f"file://{os.path.abspath(location.path)}"
         elif isinstance(location, GitLocation):
-            parsed = urlparse(location.url)
-            if parsed.username or parsed.password:
-                parsed = parsed._replace(netloc=parsed.hostname + (f":{parsed.port}" if parsed.port else ""))
-            return "git", urlunparse(parsed)
+            return "git", location.url
         elif isinstance(location, MavenLocation):
             return "maven", f"{location.group_id}:{location.artifact_id}:{location.version}"
         elif isinstance(location, PypiLocation):
@@ -330,7 +319,7 @@ class CombinedRawDatasetsGenerator:
             return "local_maven", f"file://{os.path.abspath(location.path)}"
         elif isinstance(location, LocalPypiLocation):
             return "local_pypi", f"file://{os.path.abspath(location.path)}"
-        logging.warning("Unknown location type %s; using 'unknown' prefix for tmp dir", type(location).__name__)
+        logging.warning("Unknown location type %s", type(location).__name__)
         return "unknown", None
 
     @staticmethod

--- a/src/reqstool/model_generators/combined_raw_datasets_generator.py
+++ b/src/reqstool/model_generators/combined_raw_datasets_generator.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import re
 from collections import defaultdict
 from typing import Dict, List, Optional, Set, Tuple
 
@@ -253,7 +254,9 @@ class CombinedRawDatasetsGenerator:
         mvrs_data = None
         automated_tests = None
 
-        tmp_path = self._tmpdir_manager.get_suffix_path("can_we_use_urn_here").absolute()
+        location_type, location_uri = self.__extract_location_provenance(current_location_handler.current)
+        safe_suffix = f"{location_type}_" + re.sub(r"[^a-zA-Z0-9._-]", "_", location_uri or "")[:80]
+        tmp_path = self._tmpdir_manager.get_suffix_path(safe_suffix).absolute()
 
         actual_tmp_path = current_location_handler.make_available_on_localdisk(dst_path=tmp_path)
 
@@ -279,9 +282,6 @@ class CombinedRawDatasetsGenerator:
         annotations_data, svcs_data, automated_tests, mvrs_data = self.__parse_source_other(
             actual_tmp_path, requirements_indata, rmg
         )
-
-        # Capture location provenance
-        location_type, location_uri = self.__extract_location_provenance(current_location_handler.current)
 
         # Capture resolved file paths for LocalLocation only
         source_paths = self.__extract_source_paths(current_location_handler.current, requirements_indata)

--- a/src/reqstool/model_generators/combined_raw_datasets_generator.py
+++ b/src/reqstool/model_generators/combined_raw_datasets_generator.py
@@ -4,6 +4,9 @@ import logging
 import os
 import re
 from collections import defaultdict
+
+_SUFFIX_MAX_LEN = 80
+_UNSAFE_PATH_CHARS = re.compile(r"[^a-zA-Z0-9._-]")
 from typing import Dict, List, Optional, Set, Tuple
 
 from reqstool_python_decorators.decorators.decorators import Requirements
@@ -255,7 +258,9 @@ class CombinedRawDatasetsGenerator:
         automated_tests = None
 
         location_type, location_uri = self.__extract_location_provenance(current_location_handler.current)
-        safe_suffix = f"{location_type}_" + re.sub(r"[^a-zA-Z0-9._-]", "_", location_uri or "")[:80]
+        type_prefix = location_type or "unknown"
+        sanitized_uri = re.sub(r"\.{2,}", "_", _UNSAFE_PATH_CHARS.sub("_", location_uri or ""))
+        safe_suffix = f"{type_prefix}_{sanitized_uri}"[:_SUFFIX_MAX_LEN]
         tmp_path = self._tmpdir_manager.get_suffix_path(safe_suffix).absolute()
 
         actual_tmp_path = current_location_handler.make_available_on_localdisk(dst_path=tmp_path)
@@ -302,19 +307,31 @@ class CombinedRawDatasetsGenerator:
     @staticmethod
     def __extract_location_provenance(location: LocationInterface) -> tuple:
         """Extract location_type and location_uri from a resolved location."""
+        from urllib.parse import urlparse, urlunparse
+
         from reqstool.locations.git_location import GitLocation
+        from reqstool.locations.local_maven_location import LocalMavenLocation
+        from reqstool.locations.local_pypi_location import LocalPypiLocation
         from reqstool.locations.maven_location import MavenLocation
         from reqstool.locations.pypi_location import PypiLocation
 
         if isinstance(location, LocalLocation):
             return "local", f"file://{os.path.abspath(location.path)}"
         elif isinstance(location, GitLocation):
-            return "git", location.url
+            parsed = urlparse(location.url)
+            if parsed.username or parsed.password:
+                parsed = parsed._replace(netloc=parsed.hostname + (f":{parsed.port}" if parsed.port else ""))
+            return "git", urlunparse(parsed)
         elif isinstance(location, MavenLocation):
             return "maven", f"{location.group_id}:{location.artifact_id}:{location.version}"
         elif isinstance(location, PypiLocation):
             return "pypi", f"{location.package}=={location.version}"
-        return None, None
+        elif isinstance(location, LocalMavenLocation):
+            return "local_maven", f"file://{os.path.abspath(location.path)}"
+        elif isinstance(location, LocalPypiLocation):
+            return "local_pypi", f"file://{os.path.abspath(location.path)}"
+        logging.warning("Unknown location type %s; using 'unknown' prefix for tmp dir", type(location).__name__)
+        return "unknown", None
 
     @staticmethod
     def __extract_source_paths(location: LocationInterface, requirements_indata: RequirementsIndata) -> Dict[str, str]:

--- a/tests/unit/reqstool/model_generators/test_combined_raw_datasets_generator.py
+++ b/tests/unit/reqstool/model_generators/test_combined_raw_datasets_generator.py
@@ -1,5 +1,7 @@
 # Copyright © LFV
 
+import contextlib
+import re
 from unittest.mock import patch
 
 import pytest
@@ -141,50 +143,54 @@ def test_implementation_traversal_recursive(local_testdata_resources_rootdir_w_p
     assert ("lib-c", "implementation") in crd.parsing_graph["lib-b"]
 
 
-@SVCs("SVC_020")
-def test_tmpdir_suffix_local_uses_local_prefix():
-    captured_suffixes = []
+@contextlib.contextmanager
+def _capture_suffix_calls():
+    captured = []
     original = TempDirectoryManager.get_suffix_path
 
-    def capturing(self, suffix):
-        captured_suffixes.append(suffix)
+    def _capturing(self, suffix):
+        captured.append(suffix)
         return original(self, suffix)
 
-    with patch.object(TempDirectoryManager, "get_suffix_path", capturing):
+    with patch.object(TempDirectoryManager, "get_suffix_path", _capturing):
+        yield captured
+
+
+def _assert_safe_suffix(suffix, expected_prefix, uri_fragment):
+    assert len(suffix) >= 1, "get_suffix_path was never called"
+    assert suffix.startswith(expected_prefix)
+    assert uri_fragment in suffix
+    assert re.match(r"^[a-zA-Z0-9._-]+$", suffix), f"Suffix contains unsafe chars: {suffix!r}"
+
+
+@SVCs("SVC_020")
+def test_tmpdir_suffix_local_uses_local_prefix():
+    with _capture_suffix_calls() as captured_suffixes:
         with pytest.raises(MissingRequirementsFileError):
             CombinedRawDatasetsGenerator(
                 initial_location=LocalLocation(path="/nonexistent/path"),
                 semantic_validator=SemanticValidator(validation_error_holder=ValidationErrorHolder()),
             )
-
-    assert captured_suffixes[0].startswith("local_")
-    assert "can_we_use_urn_here" not in captured_suffixes[0]
+    assert len(captured_suffixes) >= 1, "get_suffix_path was never called"
+    _assert_safe_suffix(captured_suffixes[0], "local_", "nonexistent")
 
 
 @SVCs("SVC_020")
 @pytest.mark.parametrize(
-    "location,expected_prefix",
+    "location,expected_prefix,uri_fragment",
     [
-        (GitLocation(url="https://github.com/org/repo", branch="main"), "git_"),
-        (MavenLocation(group_id="com.example", artifact_id="my-artifact", version="1.0.0"), "maven_"),
-        (PypiLocation(package="my-package", version="1.0.0"), "pypi_"),
+        (GitLocation(url="https://github.com/org/repo", branch="main"), "git_", "github.com"),
+        (MavenLocation(group_id="com.example", artifact_id="my-artifact", version="1.0.0"), "maven_", "my-artifact"),
+        (PypiLocation(package="my-package", version="1.0.0"), "pypi_", "my-package"),
     ],
 )
-def test_tmpdir_suffix_remote_uses_location_type_prefix(tmp_path, location, expected_prefix):
-    captured_suffixes = []
-    original = TempDirectoryManager.get_suffix_path
-
-    def capturing(self, suffix):
-        captured_suffixes.append(suffix)
-        return original(self, suffix)
-
-    with patch.object(TempDirectoryManager, "get_suffix_path", capturing):
+def test_tmpdir_suffix_remote_uses_location_type_prefix(tmp_path, location, expected_prefix, uri_fragment):
+    with _capture_suffix_calls() as captured_suffixes:
         with patch.object(LocationResolver, "make_available_on_localdisk", return_value=str(tmp_path)):
             with pytest.raises(MissingRequirementsFileError):
                 CombinedRawDatasetsGenerator(
                     initial_location=location,
                     semantic_validator=SemanticValidator(validation_error_holder=ValidationErrorHolder()),
                 )
-
-    assert captured_suffixes[0].startswith(expected_prefix)
-    assert "can_we_use_urn_here" not in captured_suffixes[0]
+    assert len(captured_suffixes) >= 1, "get_suffix_path was never called"
+    _assert_safe_suffix(captured_suffixes[0], expected_prefix, uri_fragment)

--- a/tests/unit/reqstool/model_generators/test_combined_raw_datasets_generator.py
+++ b/tests/unit/reqstool/model_generators/test_combined_raw_datasets_generator.py
@@ -1,13 +1,21 @@
 # Copyright © LFV
 
+from unittest.mock import patch
+
 import pytest
 from reqstool_python_decorators.decorators.decorators import SVCs
 
 from reqstool.common.exceptions import CircularImplementationError, CircularImportError, MissingRequirementsFileError
+from reqstool.common.utils import TempDirectoryManager
 from reqstool.common.validator_error_holder import ValidationErrorHolder
 from reqstool.common.validators.semantic_validator import SemanticValidator
+from reqstool.location_resolver.location_resolver import LocationResolver
+from reqstool.locations.git_location import GitLocation
 from reqstool.locations.local_location import LocalLocation
+from reqstool.locations.maven_location import MavenLocation
+from reqstool.locations.pypi_location import PypiLocation
 from reqstool.model_generators import combined_raw_datasets_generator
+from reqstool.model_generators.combined_raw_datasets_generator import CombinedRawDatasetsGenerator
 from reqstool.models.raw_datasets import CombinedRawDataset
 
 
@@ -131,3 +139,52 @@ def test_implementation_traversal_recursive(local_testdata_resources_rootdir_w_p
     assert ("lib-a", "implementation") in crd.parsing_graph["root"]
     assert ("lib-b", "implementation") in crd.parsing_graph["lib-a"]
     assert ("lib-c", "implementation") in crd.parsing_graph["lib-b"]
+
+
+@SVCs("SVC_020")
+def test_tmpdir_suffix_local_uses_local_prefix():
+    captured_suffixes = []
+    original = TempDirectoryManager.get_suffix_path
+
+    def capturing(self, suffix):
+        captured_suffixes.append(suffix)
+        return original(self, suffix)
+
+    with patch.object(TempDirectoryManager, "get_suffix_path", capturing):
+        with pytest.raises(MissingRequirementsFileError):
+            CombinedRawDatasetsGenerator(
+                initial_location=LocalLocation(path="/nonexistent/path"),
+                semantic_validator=SemanticValidator(validation_error_holder=ValidationErrorHolder()),
+            )
+
+    assert captured_suffixes[0].startswith("local_")
+    assert "can_we_use_urn_here" not in captured_suffixes[0]
+
+
+@SVCs("SVC_020")
+@pytest.mark.parametrize(
+    "location,expected_prefix",
+    [
+        (GitLocation(url="https://github.com/org/repo", branch="main"), "git_"),
+        (MavenLocation(group_id="com.example", artifact_id="my-artifact", version="1.0.0"), "maven_"),
+        (PypiLocation(package="my-package", version="1.0.0"), "pypi_"),
+    ],
+)
+def test_tmpdir_suffix_remote_uses_location_type_prefix(tmp_path, location, expected_prefix):
+    captured_suffixes = []
+    original = TempDirectoryManager.get_suffix_path
+
+    def capturing(self, suffix):
+        captured_suffixes.append(suffix)
+        return original(self, suffix)
+
+    with patch.object(TempDirectoryManager, "get_suffix_path", capturing):
+        with patch.object(LocationResolver, "make_available_on_localdisk", return_value=str(tmp_path)):
+            with pytest.raises(MissingRequirementsFileError):
+                CombinedRawDatasetsGenerator(
+                    initial_location=location,
+                    semantic_validator=SemanticValidator(validation_error_holder=ValidationErrorHolder()),
+                )
+
+    assert captured_suffixes[0].startswith(expected_prefix)
+    assert "can_we_use_urn_here" not in captured_suffixes[0]


### PR DESCRIPTION
## Summary

- Replaces the placeholder \`"can_we_use_urn_here"\` temp dir suffix in \`__parse_source()\` with a meaningful, location-based identifier
- Uses the existing \`__extract_location_provenance()\` static method (moved earlier in the method) to derive \`location_type\` and \`location_uri\`
- Constructs the suffix as \`{type}_{sanitized_uri}\` — e.g. \`local_file____path_to_demo\`, \`git_https___github.com_org_repo\`
- Removes the duplicate \`__extract_location_provenance\` call that was further down in the same method
- Adds \`LocalMavenLocation\` and \`LocalPypiLocation\` handling (previously fell through to \`None\`)
- **Strips Git URL credentials** (username/password/token) via \`urlparse\` before using the URL as a path component — tokens and usernames must never appear in filesystem paths or error messages
- Adds path-traversal containment guard in \`get_suffix_path\` (resolve-based \`is_relative_to\` check)
- Replaces consecutive \`..)\` sequences in the sanitized URI with \`_\`

## Examples

| Location type | Suffix |
|---|---|
| \`LocalLocation\` | \`local_file____path_to_reqstool_demo_docs_reqstool\` |
| \`GitLocation\` | \`git_https___github.com_org_repo\` (credentials stripped) |
| \`MavenLocation\` | \`maven_com.example_my-artifact_1.0.0\` |
| \`PypiLocation\` | \`pypi_my-package__1.0.0\` |
| \`LocalMavenLocation\` | \`local_maven_file____path_to_artifact\` |
| \`LocalPypiLocation\` | \`local_pypi_file____path_to_tarball\` |

## Security note

Git remote URLs sometimes include embedded credentials in the form \`https://token:x-oauth-basic@host/...\`. Without sanitization, the alphanumeric portions of those credentials would survive the path-safe substitution and appear as a readable directory name on disk. This PR strips the \`userinfo\` component (username + password) from Git URLs before constructing the suffix.

## Test plan

- [x] 670 unit tests pass
- [x] Smoke-tested \`status\` command against reqstool-demo — output unchanged
- [x] New tests cover all 4 location types, assert prefix, URI fragment presence, and safe-char correctness

Closes #370

Signed-off-by: Jimisola Laursen <jimisola@jimisola.com>