### PR TITLE
fix(enrich): format multiline Description/Rationale fields with label-only line and indented values

### DIFF
--- a/src/reqstool/common/enrichment/enricher.py
+++ b/src/reqstool/common/enrichment/enricher.py
@@ -50,7 +50,7 @@ def _block_field(label: str, value: str) -> list:
         return [f"**{label}**: {lines[0]}"]
     result = [f"**{label}**:"]
     for line in lines:
-        result.append("    " + line if line.strip() else "")
+        result.append("> " + line if line.strip() else ">")
     return result
 
 

--- a/src/reqstool/common/enrichment/enricher.py
+++ b/src/reqstool/common/enrichment/enricher.py
@@ -51,6 +51,7 @@ def _block_field(label: str, value: str) -> list:
     result = [f"**{label}**:"]
     for line in lines:
         result.append("> " + line if line.strip() else ">")
+    result.append("")  # paragraph break — terminates blockquote before next field
     return result
 
 
@@ -207,7 +208,7 @@ def enrich_text(  # noqa: C901
                     if info.block_lines:
                         output.append("\n")  # blank line separates heading from block
                     for bl in info.block_lines:
-                        output.append(bl + "  \n")  # trailing spaces = Markdown hard line break
+                        output.append("\n" if bl == "" else bl + "  \n")
                     last_enriched_id = id_str
                     continue
 

--- a/src/reqstool/common/enrichment/enricher.py
+++ b/src/reqstool/common/enrichment/enricher.py
@@ -50,8 +50,7 @@ def _block_field(label: str, value: str) -> list:
         return [f"**{label}**: {lines[0]}"]
     result = [f"**{label}**:"]
     for line in lines:
-        result.append("> " + line if line.strip() else ">")
-    result.append("")  # paragraph break — terminates blockquote before next field
+        result.append(line)
     return result
 
 
@@ -208,7 +207,7 @@ def enrich_text(  # noqa: C901
                     if info.block_lines:
                         output.append("\n")  # blank line separates heading from block
                     for bl in info.block_lines:
-                        output.append("\n" if bl == "" else bl + "  \n")
+                        output.append(bl + "  \n")
                     last_enriched_id = id_str
                     continue
 

--- a/src/reqstool/common/enrichment/enricher.py
+++ b/src/reqstool/common/enrichment/enricher.py
@@ -48,9 +48,13 @@ def _block_field(label: str, value: str) -> list:
         return []
     if len(lines) == 1:
         return [f"**{label}**: {lines[0]}"]
+    # U+00A0 (non-breaking space) is not stripped by CommonMark parsers (unlike U+0020),
+    # so it survives as visible indentation in react-markdown. enrich_text appends
+    # "  \n" (hard line break) to every block line, so we don't add trailing spaces here.
+    indent = " " * 4
     result = [f"**{label}**:"]
     for line in lines:
-        result.append(line)
+        result.append(indent + line if line.strip() else "")
     return result
 
 

--- a/src/reqstool/common/enrichment/enricher.py
+++ b/src/reqstool/common/enrichment/enricher.py
@@ -46,11 +46,11 @@ def _block_field(label: str, value: str) -> list:
     lines = value.splitlines()
     if not lines:
         return []
-    prefix = f"**{label}**: "
-    indent = " " * len(prefix)
-    result = [prefix + lines[0]]
-    for line in lines[1:]:
-        result.append(indent + line if line.strip() else "")
+    if len(lines) == 1:
+        return [f"**{label}**: {lines[0]}"]
+    result = [f"**{label}**:"]
+    for line in lines:
+        result.append("    " + line if line.strip() else "")
     return result
 
 

--- a/tests/resources/enrich/spec_multiline_description/expected.md
+++ b/tests/resources/enrich/spec_multiline_description/expected.md
@@ -1,9 +1,9 @@
 #### Scenario: SVC_203 — Some Title SVC_203
 
 **Description**:  
-    GIVEN a component  
-    WHEN it is invoked  
-    THEN it returns a result  
+> GIVEN a component  
+> WHEN it is invoked  
+> THEN it returns a result  
 **Verification**: Automated Test  
 **Requirements**: REQ_201  
 **Revision**: 0.0.1  

--- a/tests/resources/enrich/spec_multiline_description/expected.md
+++ b/tests/resources/enrich/spec_multiline_description/expected.md
@@ -1,10 +1,9 @@
 #### Scenario: SVC_203 — Some Title SVC_203
 
 **Description**:  
-> GIVEN a component  
-> WHEN it is invoked  
-> THEN it returns a result  
-
+GIVEN a component  
+WHEN it is invoked  
+THEN it returns a result  
 **Verification**: Automated Test  
 **Requirements**: REQ_201  
 **Revision**: 0.0.1  

--- a/tests/resources/enrich/spec_multiline_description/expected.md
+++ b/tests/resources/enrich/spec_multiline_description/expected.md
@@ -1,0 +1,10 @@
+#### Scenario: SVC_203 — Some Title SVC_203
+
+**Description**:  
+    GIVEN a component  
+    WHEN it is invoked  
+    THEN it returns a result  
+**Verification**: Automated Test  
+**Requirements**: REQ_201  
+**Revision**: 0.0.1  
+**Lifecycle**: Effective  

--- a/tests/resources/enrich/spec_multiline_description/expected.md
+++ b/tests/resources/enrich/spec_multiline_description/expected.md
@@ -4,6 +4,7 @@
 > GIVEN a component  
 > WHEN it is invoked  
 > THEN it returns a result  
+
 **Verification**: Automated Test  
 **Requirements**: REQ_201  
 **Revision**: 0.0.1  

--- a/tests/resources/enrich/spec_multiline_description/expected.md
+++ b/tests/resources/enrich/spec_multiline_description/expected.md
@@ -1,9 +1,9 @@
 #### Scenario: SVC_203 — Some Title SVC_203
 
 **Description**:  
-GIVEN a component  
-WHEN it is invoked  
-THEN it returns a result  
+    GIVEN a component  
+    WHEN it is invoked  
+    THEN it returns a result  
 **Verification**: Automated Test  
 **Requirements**: REQ_201  
 **Revision**: 0.0.1  

--- a/tests/resources/enrich/spec_multiline_description/input.md
+++ b/tests/resources/enrich/spec_multiline_description/input.md
@@ -1,0 +1,2 @@
+#### Scenario: SVC_203
+The system SHALL pass SVC_203.

--- a/tests/resources/test_data/data/local/test_basic/baseline/ms-101/software_verification_cases.yml
+++ b/tests/resources/test_data/data/local/test_basic/baseline/ms-101/software_verification_cases.yml
@@ -28,3 +28,13 @@ cases:
     verification: manual-test
     instructions: "Some instructions"
     revision: "0.0.2"
+
+  - id: SVC_203
+    requirement_ids: ["REQ_201"]
+    title: "Some Title SVC_203"
+    description: |
+      GIVEN a component
+      WHEN it is invoked
+      THEN it returns a result
+    verification: automated-test
+    revision: "0.0.1"

--- a/tests/unit/reqstool/commands/enrich/test_enrich.py
+++ b/tests/unit/reqstool/commands/enrich/test_enrich.py
@@ -63,3 +63,10 @@ def test_mvr_enrichment(ms101):
     input_content, expected = _load("mvr")
     result = EnrichCommand(location=ms101, input_content=input_content, config=BUILT_IN_PRESETS["openspec:spec"])
     assert result.result == expected
+
+
+@SVCs("SVC_039")
+def test_spec_multiline_description(ms101):
+    input_content, expected = _load("spec_multiline_description")
+    result = EnrichCommand(location=ms101, input_content=input_content, config=BUILT_IN_PRESETS["openspec:spec"])
+    assert result.result == expected

--- a/tests/unit/reqstool/common/enrichment/test_enricher.py
+++ b/tests/unit/reqstool/common/enrichment/test_enricher.py
@@ -2,12 +2,45 @@
 
 from reqstool.common.enrichment.enricher import (
     BUILT_IN_PRESETS,
+    _block_field,
     _format_value,
     _in_backtick_span,
     _is_stub,
     _make_pattern,
     enrich_text,
 )
+
+
+# ---------------------------------------------------------------------------
+# _block_field
+# ---------------------------------------------------------------------------
+
+
+def test_block_field_single_line():
+    assert _block_field("Description", "Simple one-liner") == ["**Description**: Simple one-liner"]
+
+
+def test_block_field_empty():
+    assert _block_field("Description", "") == []
+
+
+def test_block_field_multiline():
+    value = "GIVEN a component\nWHEN it is invoked\nTHEN it returns a result"
+    assert _block_field("Description", value) == [
+        "**Description**:",
+        "    GIVEN a component",
+        "    WHEN it is invoked",
+        "    THEN it returns a result",
+    ]
+
+
+def test_block_field_multiline_blank_lines_preserved():
+    assert _block_field("Description", "Line one\n\nLine three") == [
+        "**Description**:",
+        "    Line one",
+        "",
+        "    Line three",
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/reqstool/common/enrichment/test_enricher.py
+++ b/tests/unit/reqstool/common/enrichment/test_enricher.py
@@ -28,18 +28,18 @@ def test_block_field_multiline():
     value = "GIVEN a component\nWHEN it is invoked\nTHEN it returns a result"
     assert _block_field("Description", value) == [
         "**Description**:",
-        "    GIVEN a component",
-        "    WHEN it is invoked",
-        "    THEN it returns a result",
+        "> GIVEN a component",
+        "> WHEN it is invoked",
+        "> THEN it returns a result",
     ]
 
 
 def test_block_field_multiline_blank_lines_preserved():
     assert _block_field("Description", "Line one\n\nLine three") == [
         "**Description**:",
-        "    Line one",
-        "",
-        "    Line three",
+        "> Line one",
+        ">",
+        "> Line three",
     ]
 
 

--- a/tests/unit/reqstool/common/enrichment/test_enricher.py
+++ b/tests/unit/reqstool/common/enrichment/test_enricher.py
@@ -31,6 +31,7 @@ def test_block_field_multiline():
         "> GIVEN a component",
         "> WHEN it is invoked",
         "> THEN it returns a result",
+        "",
     ]
 
 
@@ -40,6 +41,7 @@ def test_block_field_multiline_blank_lines_preserved():
         "> Line one",
         ">",
         "> Line three",
+        "",
     ]
 
 

--- a/tests/unit/reqstool/common/enrichment/test_enricher.py
+++ b/tests/unit/reqstool/common/enrichment/test_enricher.py
@@ -28,20 +28,18 @@ def test_block_field_multiline():
     value = "GIVEN a component\nWHEN it is invoked\nTHEN it returns a result"
     assert _block_field("Description", value) == [
         "**Description**:",
-        "> GIVEN a component",
-        "> WHEN it is invoked",
-        "> THEN it returns a result",
-        "",
+        "GIVEN a component",
+        "WHEN it is invoked",
+        "THEN it returns a result",
     ]
 
 
 def test_block_field_multiline_blank_lines_preserved():
     assert _block_field("Description", "Line one\n\nLine three") == [
         "**Description**:",
-        "> Line one",
-        ">",
-        "> Line three",
+        "Line one",
         "",
+        "Line three",
     ]
 
 

--- a/tests/unit/reqstool/common/enrichment/test_enricher.py
+++ b/tests/unit/reqstool/common/enrichment/test_enricher.py
@@ -26,20 +26,22 @@ def test_block_field_empty():
 
 def test_block_field_multiline():
     value = "GIVEN a component\nWHEN it is invoked\nTHEN it returns a result"
+    nbsp = " " * 4
     assert _block_field("Description", value) == [
         "**Description**:",
-        "GIVEN a component",
-        "WHEN it is invoked",
-        "THEN it returns a result",
+        f"{nbsp}GIVEN a component",
+        f"{nbsp}WHEN it is invoked",
+        f"{nbsp}THEN it returns a result",
     ]
 
 
 def test_block_field_multiline_blank_lines_preserved():
+    nbsp = " " * 4
     assert _block_field("Description", "Line one\n\nLine three") == [
         "**Description**:",
-        "Line one",
+        f"{nbsp}Line one",
         "",
-        "Line three",
+        f"{nbsp}Line three",
     ]
 
 


### PR DESCRIPTION
Closes #383

## Summary

- `_block_field` in `enricher.py` now emits multiline field values with the label alone on its own line followed by each value line indented 4 spaces, instead of placing the first value line next to the label and aligning continuation lines with the first character
- Single-line values are unchanged: label and value remain on one line

**Before (multiline):**
```
**Description**: GIVEN a component
                 WHEN it is invoked
                 THEN it returns a result
```

**After (multiline):**
```
**Description**:
    GIVEN a component
    WHEN it is invoked
    THEN it returns a result
```

## Changes

- `src/reqstool/common/enrichment/enricher.py` — fix `_block_field`
- `tests/unit/reqstool/common/enrichment/test_enricher.py` — 4 new unit tests for `_block_field` (single-line, empty, multiline, blank-line preservation)
- `tests/unit/reqstool/commands/enrich/test_enrich.py` — new integration test `test_spec_multiline_description`
- `tests/resources/enrich/spec_multiline_description/` — new fixture (input + expected)
- `tests/resources/test_data/data/local/test_basic/baseline/ms-101/software_verification_cases.yml` — add SVC_203 with GIVEN/WHEN/THEN description to back the integration test

## Test plan

- [x] All 708 existing tests pass
- [ ] 4 new `_block_field` unit tests cover single-line (unchanged), empty, multiline, and blank-line-within-multiline cases
- [x] New integration test `test_spec_multiline_description` verifies end-to-end rendering with SVC_203