### PR TITLE
feat!: reference git locations by ref (branch, tag, or commit) instead of branch

### DIFF
--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -12,14 +12,14 @@ Use `-h/--help` for more information about each command and location.
 Each command accepts a location argument that specifies where the reqstool data resides:
 
 * `local` -- path on the local file system
-* `git` -- Git repository (URL, branch, optional token)
+* `git` -- Git repository (URL, ref (branch, tag, or commit SHA), optional token)
 * `maven` -- Maven artifact (ZIP)
 * `pypi` -- PyPI package (tar.gz)
 
 *Example with git location:*
 [source,bash]
 ----
-reqstool report git -u URL_TO_REPOSITORY.git -t ACCESS_TOKEN -p PATH_TO_DIR -b BRANCH_NAME
+reqstool report git -u URL_TO_REPOSITORY.git -t ACCESS_TOKEN -p PATH_TO_DIR -r REF
 ----
 
 [[status]]

--- a/docs/modules/examples/partials/requirements/requirements_microservice.yml
+++ b/docs/modules/examples/partials/requirements/requirements_microservice.yml
@@ -9,7 +9,7 @@ metadata:
 imports: #Optional
   git:
     - env_token: e.g. GITLAB_TOKEN or empty
-      branch: branch
+      ref: branch, tag, or commit SHA
       url: url
       path: path
   maven:

--- a/docs/modules/examples/partials/requirements/requirements_microservice.yml
+++ b/docs/modules/examples/partials/requirements/requirements_microservice.yml
@@ -9,7 +9,7 @@ metadata:
 imports: #Optional
   git:
     - env_token: e.g. GITLAB_TOKEN or empty
-      ref: branch, tag, or commit SHA
+      ref:
       url: url
       path: path
   maven:

--- a/docs/modules/examples/partials/requirements/requirements_system.yml
+++ b/docs/modules/examples/partials/requirements/requirements_system.yml
@@ -9,7 +9,7 @@ metadata:
 imports:
   git:
     - env_token: e.g. GITLAB_TOKEN or empty
-      branch:
+      ref:
       url:
       path:
   maven:
@@ -27,7 +27,7 @@ filters:
 implementations: # only used with type = system
   git:
     - env_token: e.g. GITLAB_TOKEN or empty
-      branch:
+      ref:
       url:
       path:
   maven:

--- a/src/reqstool/command.py
+++ b/src/reqstool/command.py
@@ -66,7 +66,7 @@ _LOCATION_DEFS = [
         "args": [
             {"flags": ["-u", "--url"], "kwargs": {"help": "url description", "required": True}},
             {"flags": ["-p", "--path"], "kwargs": {"help": "path description", "required": True}},
-            {"flags": ["-b", "--branch"], "kwargs": {"help": "branch description"}},
+            {"flags": ["-r", "--ref"], "kwargs": {"help": "git branch, tag, or commit SHA", "required": True}},
             {"flags": ["-t", "--env_token"], "kwargs": {"help": "env_token description"}},
         ],
     },
@@ -411,7 +411,7 @@ class Command:
             location = GitLocation(
                 url=args_source.url,
                 path=args_source.path,
-                branch=args_source.branch if args_source.branch else None,
+                ref=args_source.ref,
                 env_token=args_source.env_token if args_source.env_token else None,
             )
         elif "local" in args_source.source:

--- a/src/reqstool/common/exceptions.py
+++ b/src/reqstool/common/exceptions.py
@@ -37,3 +37,12 @@ class ArtifactExtractionError(Exception):
 
     def __init__(self, message: str):
         super().__init__(message)
+
+
+class GitRefNotFoundError(Exception):
+    """Raised when a git ref (branch, tag, or commit SHA) cannot be resolved in a cloned repo."""
+
+    def __init__(self, ref: str, url: str):
+        self.ref = ref
+        self.url = url
+        super().__init__(f"ref '{ref}' not found in {url}")

--- a/src/reqstool/locations/git_location.py
+++ b/src/reqstool/locations/git_location.py
@@ -4,16 +4,17 @@ import logging
 import os
 from typing import Optional
 
-from pygit2 import RemoteCallbacks, UserPass, clone_repository
+from pygit2 import Commit, RemoteCallbacks, UserPass, clone_repository
 from reqstool_python_decorators.decorators.decorators import Requirements
 
+from reqstool.common.exceptions import GitRefNotFoundError
 from reqstool.locations.location import LocationInterface, make_safe_tmpdir_suffix
 
 
 @Requirements("REQ_002")
 class GitLocation(LocationInterface):
     url: str
-    branch: str
+    ref: str
     env_token: Optional[str] = None
     path: str = ""
 
@@ -29,14 +30,23 @@ class GitLocation(LocationInterface):
     def _make_available_on_localdisk(self, dst_path: str) -> str:
         api_token = os.getenv(self.env_token) if self.env_token else None
 
-        if self.branch:
-            repo = clone_repository(
-                url=self.url, path=dst_path, checkout_branch=self.branch, callbacks=self.MyRemoteCallbacks(api_token)
-            )
-        else:
-            repo = clone_repository(url=self.url, path=dst_path, callbacks=self.MyRemoteCallbacks(api_token))
+        repo = clone_repository(url=self.url, path=dst_path, callbacks=self.MyRemoteCallbacks(api_token))
 
-        logging.debug(f"Cloned repo {self.url} (branch: {self.branch}) to {repo.workdir}\n")
+        # Resolve ref uniformly: a tag, the default branch, or a commit SHA resolve directly;
+        # a non-default branch only exists as a remote-tracking ref (origin/<ref>) after a plain clone.
+        try:
+            try:
+                obj = repo.revparse_single(self.ref)
+            except KeyError:
+                obj = repo.revparse_single(f"origin/{self.ref}")
+        except KeyError as e:
+            raise GitRefNotFoundError(self.ref, self.url) from e
+
+        commit = obj.peel(Commit)
+        repo.checkout_tree(commit)
+        repo.set_head(commit.id)  # Oid detaches HEAD at the resolved commit
+
+        logging.debug(f"Cloned repo {self.url} (ref: {self.ref}) to {repo.workdir}\n")
 
         return repo.workdir
 

--- a/src/reqstool/locations/git_location.py
+++ b/src/reqstool/locations/git_location.py
@@ -2,13 +2,19 @@
 
 import logging
 import os
+import re
 from typing import Optional
 
-from pygit2 import Commit, RemoteCallbacks, UserPass, clone_repository
+from pydantic import field_validator
+from pygit2 import Commit, GitError, RemoteCallbacks, UserPass, clone_repository
 from reqstool_python_decorators.decorators.decorators import Requirements
 
 from reqstool.common.exceptions import GitRefNotFoundError
 from reqstool.locations.location import LocationInterface, make_safe_tmpdir_suffix
+
+# Accepted ref characters: alphanumerics, '.', '/', '-', '_'.
+# Rejects control chars, '..', shell-special chars, and git revision syntax (@{, ~, ^, :).
+_VALID_REF_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._/\-]*$")
 
 
 @Requirements("REQ_002")
@@ -18,6 +24,16 @@ class GitLocation(LocationInterface):
     env_token: Optional[str] = None
     path: str = ""
 
+    @field_validator("ref")
+    @classmethod
+    def _validate_ref(cls, v: str) -> str:
+        if not _VALID_REF_RE.match(v) or ".." in v:
+            raise ValueError(
+                f"Invalid git ref '{v}': must start with an alphanumeric and contain only "
+                "alphanumerics, '.', '/', '-', '_'; '..' is not allowed."
+            )
+        return v
+
     def tmpdir_key(self) -> str:
         from urllib.parse import urlparse, urlunparse
 
@@ -25,26 +41,28 @@ class GitLocation(LocationInterface):
         if parsed.username or parsed.password:
             host = parsed.hostname or ""
             parsed = parsed._replace(netloc=host + (f":{parsed.port}" if parsed.port else ""))
-        return make_safe_tmpdir_suffix("git", urlunparse(parsed))
+        return make_safe_tmpdir_suffix("git", f"{urlunparse(parsed)}@{self.ref}")
 
     def _make_available_on_localdisk(self, dst_path: str) -> str:
         api_token = os.getenv(self.env_token) if self.env_token else None
 
         repo = clone_repository(url=self.url, path=dst_path, callbacks=self.MyRemoteCallbacks(api_token))
 
-        # Resolve ref uniformly: a tag, the default branch, or a commit SHA resolve directly;
-        # a non-default branch only exists as a remote-tracking ref (origin/<ref>) after a plain clone.
-        try:
+        # Try direct lookup first (tag, default branch, or commit SHA), then fall back to the
+        # remote-tracking ref — non-default branches only exist as origin/<ref> after a plain clone.
+        obj = None
+        for name in (self.ref, f"origin/{self.ref}"):
             try:
-                obj = repo.revparse_single(self.ref)
-            except KeyError:
-                obj = repo.revparse_single(f"origin/{self.ref}")
-        except KeyError as e:
-            raise GitRefNotFoundError(self.ref, self.url) from e
+                obj = repo.revparse_single(name)
+                break
+            except (KeyError, GitError):
+                continue
+        if obj is None:
+            raise GitRefNotFoundError(self.ref, self.url)
 
         commit = obj.peel(Commit)
         repo.checkout_tree(commit)
-        repo.set_head(commit.id)  # Oid detaches HEAD at the resolved commit
+        repo.set_head(commit.id)  # passing an Oid always results in a detached HEAD
 
         logging.debug(f"Cloned repo {self.url} (ref: {self.ref}) to {repo.workdir}\n")
 

--- a/src/reqstool/model_generators/requirements_model_generator.py
+++ b/src/reqstool/model_generators/requirements_model_generator.py
@@ -232,7 +232,7 @@ class RequirementsModelGenerator:
                     current_unresolved=GitLocation(
                         env_token=git.env_token,
                         url=git.url,
-                        branch=git.branch,
+                        ref=git.ref,
                         path=git.path or "",
                     ),
                 )

--- a/src/reqstool/models/generated/requirements_schema.py
+++ b/src/reqstool/models/generated/requirements_schema.py
@@ -55,9 +55,9 @@ class Git(BaseModel):
     """
     Token to authenticate. E.g. GITLAB_TOKEN or empty.
     """
-    branch: str
+    ref: str
     """
-    Git branch to read from.
+    Git branch, tag, or commit SHA to read from.
     """
     url: str
     """

--- a/src/reqstool/resources/schemas/v1/requirements.schema.json
+++ b/src/reqstool/resources/schemas/v1/requirements.schema.json
@@ -106,9 +106,9 @@
                     "type": "string",
                     "description": "Token to authenticate. E.g. GITLAB_TOKEN or empty."
                 },
-                "branch": {
+                "ref": {
                     "type": "string",
-                    "description": "Git branch to read from."
+                    "description": "Git branch, tag, or commit SHA to read from."
                 },
                 "url": {
                     "type": "string",
@@ -120,7 +120,7 @@
                 }
             },
             "required": [
-                "branch",
+                "ref",
                 "url"
             ]
         },

--- a/tests/integration/reqstool/model_generators/_regression_shared.py
+++ b/tests/integration/reqstool/model_generators/_regression_shared.py
@@ -2,11 +2,11 @@
 # Shared constants for regression-monorepo integration tests.
 
 _REGRESSION_REPO_URL = "https://github.com/reqstool/reqstool-regression.git"
-# Branch is intentionally 'main' (always latest regression data).
-# To pin CI to a known-good state, replace "main" with a commit SHA, e.g.:
-#   _REGRESSION_REPO_BRANCH = "abc1234def..."
-# GitLocation passes this value as checkout_branch to pygit2, which accepts SHAs.
-_REGRESSION_REPO_BRANCH = "main"
+# Ref is intentionally 'main' (always latest regression data).
+# To pin CI to a known-good state, replace "main" with a tag or commit SHA, e.g.:
+#   _REGRESSION_REPO_REF = "v1.0.0"  or  "abc1234def..."
+# GitLocation resolves this ref (branch, tag, or SHA) via pygit2 revparse_single.
+_REGRESSION_REPO_REF = "main"
 _GITHUB_TOKEN_ENV = "GITHUB_TOKEN"
 
 # Single source of truth for ecosystem names.

--- a/tests/integration/reqstool/model_generators/_regression_shared.py
+++ b/tests/integration/reqstool/model_generators/_regression_shared.py
@@ -2,10 +2,11 @@
 # Shared constants for regression-monorepo integration tests.
 
 _REGRESSION_REPO_URL = "https://github.com/reqstool/reqstool-regression.git"
-# Ref is intentionally 'main' (always latest regression data).
+# Ref is intentionally 'main' (always latest regression data). Note: after a plain clone,
+# 'main' resolves via the origin/main remote-tracking fallback in GitLocation._resolve_ref.
 # To pin CI to a known-good state, replace "main" with a tag or commit SHA, e.g.:
-#   _REGRESSION_REPO_REF = "v1.0.0"  or  "abc1234def..."
-# GitLocation resolves this ref (branch, tag, or SHA) via pygit2 revparse_single.
+#   _REGRESSION_REPO_REF = "v1.0.0"   # resolves directly (no fallback needed)
+#   _REGRESSION_REPO_REF = "abc1234"  # resolves directly as commit SHA
 _REGRESSION_REPO_REF = "main"
 _GITHUB_TOKEN_ENV = "GITHUB_TOKEN"
 

--- a/tests/integration/reqstool/model_generators/test_included_models_generator.py
+++ b/tests/integration/reqstool/model_generators/test_included_models_generator.py
@@ -33,7 +33,7 @@ def test_basic_git():
             env_token=choose_token(),
             url="https://github.com/reqstool/reqstool-client.git",
             path="tests/resources/test_data/data/remote/test_standard/test_standard_maven_git/ms-001",
-            branch="main",
+            ref="main",
         ),
         semantic_validator=semantic_validator,
     )

--- a/tests/integration/reqstool/model_generators/test_regression_monorepo.py
+++ b/tests/integration/reqstool/model_generators/test_regression_monorepo.py
@@ -5,7 +5,7 @@ import pytest
 from integration.reqstool.model_generators._regression_shared import (
     ECOSYSTEM_PATHS,
     _GITHUB_TOKEN_ENV,
-    _REGRESSION_REPO_BRANCH,
+    _REGRESSION_REPO_REF,
     _REGRESSION_REPO_URL,
 )
 from reqstool.common.validator_error_holder import ValidationErrorHolder
@@ -30,7 +30,7 @@ def _make_generator(path: str, tmpdir_manager=None):
         initial_location=GitLocation(
             env_token=_GITHUB_TOKEN_ENV,
             url=_REGRESSION_REPO_URL,
-            branch=_REGRESSION_REPO_BRANCH,
+            ref=_REGRESSION_REPO_REF,
             path=path,
         ),
         semantic_validator=SemanticValidator(validation_error_holder=holder),

--- a/tests/integration/reqstool/model_generators/test_regression_structure.py
+++ b/tests/integration/reqstool/model_generators/test_regression_structure.py
@@ -5,7 +5,7 @@ import pytest
 from integration.reqstool.model_generators._regression_shared import (
     ECOSYSTEM_URNS,
     _GITHUB_TOKEN_ENV,
-    _REGRESSION_REPO_BRANCH,
+    _REGRESSION_REPO_REF,
     _REGRESSION_REPO_URL,
 )
 from reqstool.common.models.lifecycle import LIFECYCLESTATE
@@ -40,7 +40,7 @@ def repo():
         location=GitLocation(
             env_token=_GITHUB_TOKEN_ENV,
             url=_REGRESSION_REPO_URL,
-            branch=_REGRESSION_REPO_BRANCH,
+            ref=_REGRESSION_REPO_REF,
             path="fixtures/parent",
         ),
         semantic_validator=SemanticValidator(validation_error_holder=holder),

--- a/tests/resources/test_data/data/remote/test_standard/test_standard_maven_git/sys-001/requirements.yml
+++ b/tests/resources/test_data/data/remote/test_standard/test_standard_maven_git/sys-001/requirements.yml
@@ -18,7 +18,7 @@ filters:
 
 implementations:
   git:
-    - branch: main
+    - ref: main
       env_token: GITLAB_TOKEN
       url: "https://github.com/reqstool/requirements-tool-testdata.git"
       path: "data/remote/test_standard/test_standard_maven_git/ms-001"

--- a/tests/resources/unit/reqstool/model_generators/test_requirements_model_generator/test_microservice_requirements_model_generator/requirements.yml
+++ b/tests/resources/unit/reqstool/model_generators/test_requirements_model_generator/test_microservice_requirements_model_generator/requirements.yml
@@ -10,7 +10,7 @@ imports:
   git:
     - env_token: "GITLAB_TOKEN"
       url: https://gitlab.ms-example.com
-      branch: main
+      ref: main
       path: /some/ms-path
   local:
     - path: /some/local-ms-path

--- a/tests/resources/unit/reqstool/model_generators/test_requirements_model_generator/test_system_requirements_model_generator/requirements.yml
+++ b/tests/resources/unit/reqstool/model_generators/test_requirements_model_generator/test_system_requirements_model_generator/requirements.yml
@@ -9,7 +9,7 @@ imports:
   git:
     - env_token: "GITLAB_TOKEN"
       url: https://gitlab.sys-example.com
-      branch: feature/sys
+      ref: feature/sys
       path: /some/path
   local:
     - path: /some/local-sys-path
@@ -53,7 +53,7 @@ implementations: # only used with type = system
   git:
     - env_token: GITLAB_TOKEN
       url: https://gitlab.impl-example.com
-      branch: feature/impl
+      ref: feature/impl
       path: README.md
 
   local: # for future use

--- a/tests/unit/reqstool/common/test_locations.py
+++ b/tests/unit/reqstool/common/test_locations.py
@@ -11,7 +11,7 @@ from reqstool.locations.maven_location import MavenLocation
 def git_location_data():
     return GitLocation(
         env_token="GITLAB_TOKEN",
-        branch="main",
+        ref="main",
         url="https://gitlab.example.com",
         path="some/path",
     )
@@ -36,7 +36,7 @@ def maven_location_data():
 
 def test_git_location_data(git_location_data):
     assert git_location_data.env_token == "GITLAB_TOKEN"
-    assert git_location_data.branch == "main"
+    assert git_location_data.ref == "main"
     assert git_location_data.url == "https://gitlab.example.com"
     assert git_location_data.path == "some/path"
 

--- a/tests/unit/reqstool/locations/test_git_location.py
+++ b/tests/unit/reqstool/locations/test_git_location.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from reqstool.common.exceptions import GitRefNotFoundError
 from reqstool.locations.git_location import GitLocation
@@ -62,6 +63,39 @@ def test_git_location_env_token_defaults_to_none():
     assert git_location.env_token is None
 
 
+@pytest.mark.parametrize(
+    "ref",
+    ["main", "v1.2.0", "feature/my-feature", "abc1234def5678", "release_1.0", "some.branch"],
+)
+def test_git_location_valid_ref_accepted(ref):
+    git_location = GitLocation(url="https://git.example.com/repo.git", ref=ref)
+    assert git_location.ref == ref
+
+
+@pytest.mark.parametrize(
+    "ref",
+    [
+        "my..ref",  # double-dot (git range syntax)
+        "@{upstream}",  # git reflog syntax
+        "ref~1",  # relative ref
+        "ref^",  # parent syntax
+        "ref:path",  # colon (git tree-ish)
+        "ref name",  # space
+        ".hidden",  # starts with dot
+        "-branch",  # starts with dash
+        "ref\x00",  # null byte
+    ],
+)
+def test_git_location_invalid_ref_rejected(ref):
+    with pytest.raises(ValidationError):
+        GitLocation(url="https://git.example.com/repo.git", ref=ref)
+
+
+def test_git_location_tmpdir_key_includes_ref():
+    loc = GitLocation(url="https://git.example.com/repo.git", ref="v1.0.0")
+    assert "v1.0.0" in loc.tmpdir_key()
+
+
 def _mock_repo(tmp_path):
     """A cloned-repo mock whose ref resolution and checkout calls are observable."""
     mock_repo = MagicMock()
@@ -114,3 +148,16 @@ def test_git_location_make_available_unresolvable_ref_raises(tmp_path):
 
     assert exc_info.value.ref == "nope"
     assert exc_info.value.url == "https://git.example.com/repo.git"
+
+
+def test_git_location_make_available_git_error_treated_as_not_found(tmp_path):
+    """A pygit2.GitError (e.g. malformed ref reaching revparse) is handled like a missing ref."""
+    from pygit2 import GitError
+
+    git_location = GitLocation(url="https://git.example.com/repo.git", ref="valid-ref", path="")
+    mock_repo = _mock_repo(tmp_path)
+    mock_repo.revparse_single.side_effect = GitError("internal error")
+
+    with patch("reqstool.locations.git_location.clone_repository", return_value=mock_repo):
+        with pytest.raises(GitRefNotFoundError):
+            git_location._make_available_on_localdisk(str(tmp_path))

--- a/tests/unit/reqstool/locations/test_git_location.py
+++ b/tests/unit/reqstool/locations/test_git_location.py
@@ -2,41 +2,44 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from reqstool.common.exceptions import GitRefNotFoundError
 from reqstool.locations.git_location import GitLocation
 
 
-def test_git_location(resource_funcname_rootdir_w_path):
+def test_git_location():
     PATH = "/tmp/somepath"
 
     git_location = GitLocation(
         env_token="GITLAB_TOKEN",
         url="https://git.example.com/example/repo.git",
-        branch="main",
+        ref="main",
         path=PATH,
     )
 
     assert git_location.env_token == "GITLAB_TOKEN"
     assert git_location.url == "https://git.example.com/example/repo.git"
-    assert git_location.branch == "main"
+    assert git_location.ref == "main"
     assert git_location.path == PATH
 
     git_location = GitLocation(
         env_token="CI_TOKEN",
         url="https://git.example.com/repo.git",
-        branch="test",
+        ref="v1.2.0",
         path=PATH,
     )
 
     assert git_location.env_token == "CI_TOKEN"
     assert git_location.url == "https://git.example.com/repo.git"
-    assert git_location.branch == "test"
+    assert git_location.ref == "v1.2.0"
     assert git_location.path == PATH
 
 
 def test_git_location_path_defaults_to_empty_string():
     git_location = GitLocation(
         url="https://git.example.com/repo.git",
-        branch="main",
+        ref="main",
     )
     assert git_location.path == ""
 
@@ -44,7 +47,7 @@ def test_git_location_path_defaults_to_empty_string():
 def test_git_location_explicit_path_still_works():
     git_location = GitLocation(
         url="https://git.example.com/repo.git",
-        branch="main",
+        ref="main",
         path="docs/reqstool",
     )
     assert git_location.path == "docs/reqstool"
@@ -53,17 +56,61 @@ def test_git_location_explicit_path_still_works():
 def test_git_location_env_token_defaults_to_none():
     git_location = GitLocation(
         url="https://git.example.com/repo.git",
-        branch="main",
+        ref="main",
         path="/tmp/somepath",
     )
     assert git_location.env_token is None
 
 
-def test_git_location_make_available_no_env_token(tmp_path):
-    git_location = GitLocation(url="https://git.example.com/repo.git", branch="main", path="")
+def _mock_repo(tmp_path):
+    """A cloned-repo mock whose ref resolution and checkout calls are observable."""
     mock_repo = MagicMock()
     mock_repo.workdir = str(tmp_path)
+    return mock_repo
+
+
+@pytest.mark.parametrize("ref", ["v1.2.0", "main", "abc1234def5678"])
+def test_git_location_make_available_resolves_ref(tmp_path, ref):
+    """A tag, default branch, or SHA resolves directly via revparse_single and is checked out."""
+    git_location = GitLocation(url="https://git.example.com/repo.git", ref=ref, path="")
+    mock_repo = _mock_repo(tmp_path)
+
     with patch("reqstool.locations.git_location.clone_repository", return_value=mock_repo) as mock_clone:
         result = git_location._make_available_on_localdisk(str(tmp_path))
+
     mock_clone.assert_called_once()
+    mock_repo.revparse_single.assert_called_once_with(ref)
+    commit = mock_repo.revparse_single.return_value.peel.return_value
+    mock_repo.checkout_tree.assert_called_once_with(commit)
+    mock_repo.set_head.assert_called_once_with(commit.id)
     assert result == str(tmp_path)
+
+
+def test_git_location_make_available_non_default_branch_uses_origin_fallback(tmp_path):
+    """A non-default branch only exists as origin/<ref> after a plain clone, so the fallback is used."""
+    git_location = GitLocation(url="https://git.example.com/repo.git", ref="feature/x", path="")
+    mock_repo = _mock_repo(tmp_path)
+    resolved = MagicMock()
+    # First lookup (bare ref) misses; origin/<ref> resolves.
+    mock_repo.revparse_single.side_effect = [KeyError("feature/x"), resolved]
+
+    with patch("reqstool.locations.git_location.clone_repository", return_value=mock_repo):
+        result = git_location._make_available_on_localdisk(str(tmp_path))
+
+    assert [c.args[0] for c in mock_repo.revparse_single.call_args_list] == ["feature/x", "origin/feature/x"]
+    mock_repo.checkout_tree.assert_called_once_with(resolved.peel.return_value)
+    assert result == str(tmp_path)
+
+
+def test_git_location_make_available_unresolvable_ref_raises(tmp_path):
+    """An unresolvable ref (typo, deleted tag) raises a clear GitRefNotFoundError."""
+    git_location = GitLocation(url="https://git.example.com/repo.git", ref="nope", path="")
+    mock_repo = _mock_repo(tmp_path)
+    mock_repo.revparse_single.side_effect = KeyError("nope")
+
+    with patch("reqstool.locations.git_location.clone_repository", return_value=mock_repo):
+        with pytest.raises(GitRefNotFoundError) as exc_info:
+            git_location._make_available_on_localdisk(str(tmp_path))
+
+    assert exc_info.value.ref == "nope"
+    assert exc_info.value.url == "https://git.example.com/repo.git"

--- a/tests/unit/reqstool/model_generators/test_combined_raw_datasets_generator.py
+++ b/tests/unit/reqstool/model_generators/test_combined_raw_datasets_generator.py
@@ -179,7 +179,7 @@ def test_tmpdir_suffix_local_uses_local_prefix():
 @pytest.mark.parametrize(
     "location,expected_prefix,uri_fragment",
     [
-        (GitLocation(url="https://github.com/org/repo", branch="main"), "git_", "github.com"),
+        (GitLocation(url="https://github.com/org/repo", ref="main"), "git_", "github.com"),
         (MavenLocation(group_id="com.example", artifact_id="my-artifact", version="1.0.0"), "maven_", "my-artifact"),
         (PypiLocation(package="my-package", version="1.0.0"), "pypi_", "my-package"),
     ],

--- a/tests/unit/reqstool/model_generators/test_requirements_model_generator.py
+++ b/tests/unit/reqstool/model_generators/test_requirements_model_generator.py
@@ -43,7 +43,7 @@ def test_system_requirements_model_generator(resource_funcname_rootdir_w_path):
     # git
     assert model.imports[1].current_unresolved.env_token == "GITLAB_TOKEN"
     assert model.imports[1].current_unresolved.url == "https://gitlab.sys-example.com"
-    assert model.imports[1].current_unresolved.branch == "feature/sys"
+    assert model.imports[1].current_unresolved.ref == "feature/sys"
     assert model.imports[1].current_unresolved.path == "/some/path"
 
     # maven #1
@@ -83,7 +83,7 @@ def test_system_requirements_model_generator(resource_funcname_rootdir_w_path):
     # git
     assert model.implementations[1].current_unresolved.env_token == "GITLAB_TOKEN"
     assert model.implementations[1].current_unresolved.url == "https://gitlab.impl-example.com"
-    assert model.implementations[1].current_unresolved.branch == "feature/impl"
+    assert model.implementations[1].current_unresolved.ref == "feature/impl"
     assert model.implementations[1].current_unresolved.path == "README.md"
 
     # maven #1
@@ -145,7 +145,7 @@ def test_microservice_requirements_model_generator(resource_funcname_rootdir_w_p
     # git
     assert model.imports[1].current_unresolved.env_token == "GITLAB_TOKEN"
     assert model.imports[1].current_unresolved.url == "https://gitlab.ms-example.com"
-    assert model.imports[1].current_unresolved.branch == "main"
+    assert model.imports[1].current_unresolved.ref == "main"
     assert model.imports[1].current_unresolved.path == "/some/ms-path"
 
     # maven

--- a/tests/unit/reqstool/models/test_implementations.py
+++ b/tests/unit/reqstool/models/test_implementations.py
@@ -14,7 +14,7 @@ def git_impl_data() -> GitImplData:
         parent=None,
         current_unresolved=GitLocation(
             env_token="GITLAB_TOKEN",
-            branch="main",
+            ref="main",
             url="https://github.com/reqstool/reqstool-client",
             path="/examples/README.adoc",
         ),
@@ -49,7 +49,7 @@ def implementations_data(maven_impl_data):
 def test_git_impl_data(git_impl_data):
     assert git_impl_data.parent is None
     assert git_impl_data.current.env_token == "GITLAB_TOKEN"
-    assert git_impl_data.current.branch == "main"
+    assert git_impl_data.current.ref == "main"
     assert git_impl_data.current.url == "https://github.com/reqstool/reqstool-client"
     assert git_impl_data.current.path == "/examples/README.adoc"
 

--- a/tests/unit/reqstool/models/test_imports.py
+++ b/tests/unit/reqstool/models/test_imports.py
@@ -14,7 +14,7 @@ def git_import_data():
         parent=None,
         current_unresolved=GitLocation(
             env_token="GITLAB_TOKEN",
-            branch="main",
+            ref="main",
             url="https://gitlab.example.com",
             path="git/some/path",
         ),
@@ -44,7 +44,7 @@ def maven_import_data():
 def test_git_import_data(git_import_data):
     assert git_import_data.parent is None
     assert git_import_data.current.env_token == "GITLAB_TOKEN"
-    assert git_import_data.current.branch == "main"
+    assert git_import_data.current.ref == "main"
     assert git_import_data.current.url == "https://gitlab.example.com"
     assert git_import_data.current.path == "git/some/path"
 

--- a/tests/unit/reqstool/test_command.py
+++ b/tests/unit/reqstool/test_command.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from reqstool.command import Command, main
 from reqstool.commands.exit_codes import EXIT_CODE_ALL_REQS_NOT_IMPLEMENTED, EXIT_CODE_MISSING_REQUIREMENTS_FILE
 from reqstool.common.exceptions import MissingRequirementsFileError
@@ -133,14 +135,20 @@ def test_local_source_parser_accepts_path_arg():
     assert args.path == "/some/path"
 
 
-def test_git_source_parser_requires_url_and_path():
+def test_git_source_parser_requires_url_path_and_ref():
     args = _make_command_and_parse(
-        ["reqstool", "report", "git", "-u", "https://example.com/repo", "-p", "docs/reqstool"]
+        ["reqstool", "report", "git", "-u", "https://example.com/repo", "-p", "docs/reqstool", "-r", "v1.0.0"]
     )
     assert args.command == "report"
     assert args.source == "git"
     assert args.url == "https://example.com/repo"
     assert args.path == "docs/reqstool"
+    assert args.ref == "v1.0.0"
+
+
+def test_git_source_parser_missing_ref_errors():
+    with pytest.raises(SystemExit):
+        _make_command_and_parse(["reqstool", "report", "git", "-u", "https://example.com/repo", "-p", "docs/reqstool"])
 
 
 def test_maven_source_parser_requires_group_artifact_version():


### PR DESCRIPTION
Closes #159.

Git locations could previously only be pinned to a **branch**. This replaces the `branch` field with a single, required **`ref`** that accepts a branch, **tag**, or commit SHA — resolved uniformly via `pygit2.revparse_single` (with an `origin/<ref>` fallback for non-default branches) and checked out as a detached HEAD.

## Changes
- **Schema**: `git.branch` → `git.ref` (`"Git branch, tag, or commit SHA"`); `required: [ref, url]`. Generated pydantic model regenerated.
- **`GitLocation`**: `branch` field → `ref`; plain clone + `revparse_single` resolution + detached checkout.
- **New exception**: `GitRefNotFoundError(ref, url)` raised on an unresolvable ref.
- **CLI**: `-b/--branch` → `-r/--ref` (required).
- **Docs**: `usage.adoc` + example partials updated to `ref`.
- **Tests**: `branch`→`ref` across unit/integration tests and fixtures; new coverage for tag/SHA/default-branch resolution, the `origin/` fallback, the `GitRefNotFoundError` case, and a CLI missing-`--ref` error.

## Verification
- `hatch run dev:codegen-check` ✅ (model in sync with schema)
- `hatch run dev:black` / `dev:flake8` ✅
- `hatch run dev:pytest tests/unit` → **680 passed** ✅
- `report git --help` shows required `-r REF`, no `--branch`; local-fixture `status` output unchanged.

## ⚠️ Breaking change
The `branch:` field is removed and `ref` is now required; CLI `-b/--branch` becomes `-r/--ref`. Migrate `branch: <value>` → `ref: <value>`. Communicated in release notes (no CHANGELOG file in repo).