### PR TITLE
feat(locations): interpolate environment variables in YAML input (#158)

### DIFF
--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -22,6 +22,44 @@ Each command accepts a location argument that specifies where the reqstool data 
 reqstool report git -u URL_TO_REPOSITORY.git -t ACCESS_TOKEN -p PATH_TO_DIR -r REF
 ----
 
+[[env-var-interpolation]]
+== Environment variable interpolation
+
+Reqstool expands environment variables in YAML input (`requirements.yml`, `svcs.yml`,
+`mvrs.yml`, `annotations.yml`, `reqstool_config.yml`) before parsing, using POSIX shell
+parameter expansion (the `envsubst` standard). Only the *braced* form is interpolated:
+
+[cols="1,3"]
+|===
+| Syntax | Behaviour
+
+| `${VAR}`            | Substitute the value of `VAR`.
+| `${VAR:-default}`   | Use `default` when `VAR` is unset or empty.
+| `${VAR:?message}`   | Fail with `message` when `VAR` is unset or empty.
+| `${VAR:+alt}`       | Use `alt` when `VAR` is set.
+|===
+
+A bare `${VAR}` whose variable is unset and has no inline default is a *hard error* -- this
+keeps ingestion deterministic and surfaces misconfiguration in CI rather than silently
+producing empty values.
+
+The bare `$VAR` form (without braces) is intentionally *not* expanded, so the
+`# yaml-language-server: $schema=...` directive, regular expressions and other literal `$`
+characters are left untouched.
+
+This is the recommended way to keep imported artifact versions current -- pin the version to
+an environment variable and let a tool such as Renovate update it:
+
+[source,yaml]
+----
+imports:
+  maven:
+    - url: https://repo.maven.org
+      group_id: com.example
+      artifact_id: my-lib
+      version: ${MY_LIB_VERSION}
+----
+
 [[status]]
 == Command: status
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     "packaging==26.2",
     "requests==2.34.2",
     "beautifulsoup4==4.14.3",
+    "expandvars==1.1.2",
     "pygls>=2.0,<3.0",
     "lsprotocol>=2024.0.0",
     "mcp>=1.0",

--- a/src/reqstool/common/exceptions.py
+++ b/src/reqstool/common/exceptions.py
@@ -46,3 +46,16 @@ class GitRefNotFoundError(Exception):
         self.ref = ref
         self.url = url
         super().__init__(f"ref '{ref}' not found in {url}")
+
+
+class EnvVarInterpolationError(Exception):
+    """Raised when environment variable interpolation of YAML input fails.
+
+    This covers references to unset variables that have no inline default, as
+    well as malformed ``${...}`` expressions. Failing hard keeps ingestion
+    deterministic and surfaces configuration mistakes in CI.
+    """
+
+    def __init__(self, message: str, source: str | None = None):
+        self.source = source
+        super().__init__(f"{message} (in {source})" if source else message)

--- a/src/reqstool/common/utils.py
+++ b/src/reqstool/common/utils.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import re
 import tarfile
 import tempfile
 from importlib.metadata import version
@@ -10,10 +11,12 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Sequence
 from zipfile import ZipFile
 
+import expandvars
 import requests
 from packaging.version import InvalidVersion, Version as PkgVersion
 from requests_file import FileAdapter
 
+from reqstool.common.exceptions import EnvVarInterpolationError
 from reqstool.common.models.urn_id import UrnId
 from reqstool.models.raw_datasets import RawDataset
 from reqstool.models.requirements import RequirementData
@@ -23,6 +26,45 @@ from reqstool.models.svcs import SVCData
 class Utils:
 
     is_installed_package: bool = True
+
+    # Only the braced ``${...}`` form is interpolated. The bare ``$VAR`` form is
+    # intentionally left untouched: reqstool YAML files routinely contain a
+    # ``# yaml-language-server: $schema=...`` directive (and regexes, prices,
+    # etc.) where a stray ``$`` must not be treated as a variable reference.
+    _ENV_VAR_PATTERN = re.compile(r"\$\{[^{}]*\}")
+
+    @staticmethod
+    def interpolate_env_vars(text: str, source: str | None = None) -> str:
+        """Expand environment variables in raw YAML text before parsing.
+
+        Uses POSIX shell parameter expansion (the ``envsubst`` standard),
+        restricted to the braced form::
+
+            ${VAR}            substitute the value of VAR
+            ${VAR:-default}   use ``default`` when VAR is unset or empty
+            ${VAR:?message}   fail with ``message`` when VAR is unset or empty
+            ${VAR:+alt}       use ``alt`` when VAR is set
+
+        A bare ``${VAR}`` whose variable is unset (and has no inline default)
+        is a hard error: this keeps ingestion deterministic and catches
+        misconfiguration in CI rather than silently producing empty values.
+
+        Args:
+            text: raw file contents to interpolate.
+            source: optional file path/URI used in error messages.
+
+        Raises:
+            EnvVarInterpolationError: on an unset variable without a default or
+                a malformed ``${...}`` expression.
+        """
+
+        def _expand(match: "re.Match[str]") -> str:
+            try:
+                return expandvars.expand(match.group(0), nounset=True)
+            except expandvars.ExpandvarsException as e:
+                raise EnvVarInterpolationError(str(e), source=source) from e
+
+        return Utils._ENV_VAR_PATTERN.sub(_expand, text)
 
     @staticmethod
     def get_version() -> str:

--- a/src/reqstool/model_generators/annotations_model_generator.py
+++ b/src/reqstool/model_generators/annotations_model_generator.py
@@ -24,7 +24,7 @@ class AnnotationsModelGenerator:
 
         yaml = YAML(typ="safe")
 
-        data: dict = yaml.load(response.text)
+        data: dict = yaml.load(Utils.interpolate_env_vars(response.text, source=uri))
 
         if not SyntaxValidator.is_valid_data(json_schema_type=JsonSchemaTypes.ANNOTATIONS, data=data, urn=self.urn):
             sys.exit(EXIT_CODE_SYNTAX_VALIDATION_ERROR)

--- a/src/reqstool/model_generators/mvrs_model_generator.py
+++ b/src/reqstool/model_generators/mvrs_model_generator.py
@@ -26,7 +26,7 @@ class MVRsModelGenerator:
 
         yaml = YAML(typ="safe")
 
-        data: dict = yaml.load(response.text)
+        data: dict = yaml.load(Utils.interpolate_env_vars(response.text, source=uri))
 
         if not SyntaxValidator.is_valid_data(
             json_schema_type=JsonSchemaTypes.MANUAL_VERIFICATION_RESULTS, data=data, urn=self.urn

--- a/src/reqstool/model_generators/requirements_model_generator.py
+++ b/src/reqstool/model_generators/requirements_model_generator.py
@@ -87,7 +87,7 @@ class RequirementsModelGenerator:
 
         yaml = YAML(typ="safe")
 
-        data = yaml.load(response.text)
+        data = yaml.load(Utils.interpolate_env_vars(response.text, source=uri))
 
         urn = self.get_urn_if_available(response.text)
 

--- a/src/reqstool/model_generators/svcs_model_generator.py
+++ b/src/reqstool/model_generators/svcs_model_generator.py
@@ -37,7 +37,7 @@ class SVCsModelGenerator:
 
         yaml = YAML(typ="safe")
 
-        data: dict = yaml.load(response.text)
+        data: dict = yaml.load(Utils.interpolate_env_vars(response.text, source=uri))
 
         if not SyntaxValidator.is_valid_data(
             json_schema_type=JsonSchemaTypes.SOFTWARE_VERIFICATION_CASES, data=data, urn=self.urn

--- a/src/reqstool/requirements_indata/requirements_indata.py
+++ b/src/reqstool/requirements_indata/requirements_indata.py
@@ -41,11 +41,12 @@ class RequirementsIndata(BaseModel):
     def _handle_requirements_config(self):
 
         if os.path.exists(os.path.join(self.dst_path, "reqstool_config.yml")):
-            response = Utils.open_file_https_file(os.path.join(self.dst_path, "reqstool_config.yml"))
+            config_path = os.path.join(self.dst_path, "reqstool_config.yml")
+            response = Utils.open_file_https_file(config_path)
 
             yaml = YAML(typ="safe")
 
-            data: dict = yaml.load(response.text)
+            data: dict = yaml.load(Utils.interpolate_env_vars(response.text, source=config_path))
 
             if not SyntaxValidator.is_valid_data(
                 json_schema_type=JsonSchemaTypes.REQSTOOL_CONFIG, data=data, urn="unknown"

--- a/tests/resources/unit/reqstool/model_generators/test_requirements_model_generator/test_requirements_model_generator_interpolates_env_vars/requirements.yml
+++ b/tests/resources/unit/reqstool/model_generators/test_requirements_model_generator/test_requirements_model_generator_interpolates_env_vars/requirements.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+
+metadata:
+  urn: sys-001
+  variant: system
+  title: ${REQSTOOL_TEST_TITLE:-Default Title}
+
+imports:
+  maven:
+    - url: https://repo.maven.org
+      group_id: com.example.one
+      artifact_id: test-one
+      version: ${REQSTOOL_TEST_MAVEN_VERSION}
+
+requirements:
+  - id: REQ_001
+    title: Title REQ_001
+    significance: may
+    description: Description REQ_001
+    rationale: Rationale REQ_001
+    categories: ["maintainability"]
+    revision: 0.0.1

--- a/tests/resources/unit/reqstool/model_generators/test_requirements_model_generator/test_requirements_model_generator_unset_env_var_raises/requirements.yml
+++ b/tests/resources/unit/reqstool/model_generators/test_requirements_model_generator/test_requirements_model_generator_unset_env_var_raises/requirements.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+
+metadata:
+  urn: sys-001
+  variant: system
+  title: ${REQSTOOL_TEST_TITLE:-Default Title}
+
+imports:
+  maven:
+    - url: https://repo.maven.org
+      group_id: com.example.one
+      artifact_id: test-one
+      version: ${REQSTOOL_TEST_MAVEN_VERSION}
+
+requirements:
+  - id: REQ_001
+    title: Title REQ_001
+    significance: may
+    description: Description REQ_001
+    rationale: Rationale REQ_001
+    categories: ["maintainability"]
+    revision: 0.0.1

--- a/tests/unit/reqstool/common/test_utils.py
+++ b/tests/unit/reqstool/common/test_utils.py
@@ -1,6 +1,9 @@
 # Copyright © LFV
 
 
+import pytest
+
+from reqstool.common.exceptions import EnvVarInterpolationError
 from reqstool.common.utils import Utils
 
 
@@ -24,3 +27,46 @@ def test_check_ids_to_filter_mixed_ids():
     assert "ms-001:REQ_001" in result
     assert "ms-001:REQ_002" in result
     assert "other-urn:REQ_003" not in result
+
+
+def test_interpolate_env_vars_substitutes_braced_var(monkeypatch):
+    monkeypatch.setenv("REQSTOOL_VERSION", "1.2.3")
+    assert Utils.interpolate_env_vars("version: ${REQSTOOL_VERSION}") == "version: 1.2.3"
+
+
+def test_interpolate_env_vars_uses_default_when_unset(monkeypatch):
+    monkeypatch.delenv("REQSTOOL_VERSION", raising=False)
+    assert Utils.interpolate_env_vars("version: ${REQSTOOL_VERSION:-9.9.9}") == "version: 9.9.9"
+
+
+def test_interpolate_env_vars_default_overridden_when_set(monkeypatch):
+    monkeypatch.setenv("REQSTOOL_VERSION", "1.2.3")
+    assert Utils.interpolate_env_vars("version: ${REQSTOOL_VERSION:-9.9.9}") == "version: 1.2.3"
+
+
+def test_interpolate_env_vars_unset_without_default_is_hard_error(monkeypatch):
+    monkeypatch.delenv("REQSTOOL_MISSING", raising=False)
+    with pytest.raises(EnvVarInterpolationError) as exc_info:
+        Utils.interpolate_env_vars("version: ${REQSTOOL_MISSING}", source="requirements.yml")
+    assert "REQSTOOL_MISSING" in str(exc_info.value)
+    assert "requirements.yml" in str(exc_info.value)
+
+
+def test_interpolate_env_vars_required_form_raises_custom_message(monkeypatch):
+    monkeypatch.delenv("REQSTOOL_MISSING", raising=False)
+    with pytest.raises(EnvVarInterpolationError) as exc_info:
+        Utils.interpolate_env_vars("version: ${REQSTOOL_MISSING:?must be provided}")
+    assert "must be provided" in str(exc_info.value)
+
+
+def test_interpolate_env_vars_leaves_bare_dollar_and_schema_directive_untouched(monkeypatch):
+    # bare $VAR is intentionally not expanded: $schema directives, regexes and
+    # prices must survive unchanged.
+    monkeypatch.delenv("schema", raising=False)
+    text = "# yaml-language-server: $schema=https://example/schema.json\n" "note: price $5, regex ^foo$, literal $$"
+    assert Utils.interpolate_env_vars(text) == text
+
+
+def test_interpolate_env_vars_noop_on_text_without_placeholders():
+    text = "version: 1.0.0\nname: reqstool\n"
+    assert Utils.interpolate_env_vars(text) == text

--- a/tests/unit/reqstool/model_generators/test_requirements_model_generator.py
+++ b/tests/unit/reqstool/model_generators/test_requirements_model_generator.py
@@ -1,6 +1,9 @@
 # Copyright © LFV
 
 
+import pytest
+
+from reqstool.common.exceptions import EnvVarInterpolationError
 from reqstool.common.models.lifecycle import LIFECYCLESTATE
 from reqstool.common.models.urn_id import UrnId
 from reqstool.common.validator_error_holder import ValidationErrorHolder
@@ -256,3 +259,34 @@ def test_lifecycle_variable_model_generator(resource_funcname_rootdir_w_path):
     assert requirements[UrnId(urn="ms-001", id="REQ_003")].lifecycle.reason == "Reason for being obsolete"
     assert requirements[UrnId(urn="ms-001", id="REQ_004")].lifecycle.state == LIFECYCLESTATE.DRAFT
     assert requirements[UrnId(urn="ms-001", id="REQ_004")].lifecycle.reason == "Unnecessary reason"
+
+
+def test_requirements_model_generator_interpolates_env_vars(resource_funcname_rootdir_w_path, monkeypatch):
+    monkeypatch.setenv("REQSTOOL_TEST_MAVEN_VERSION", "9.9.9")
+    monkeypatch.delenv("REQSTOOL_TEST_TITLE", raising=False)  # exercise the ${VAR:-default} form
+
+    semantic_validator = SemanticValidator(validation_error_holder=ValidationErrorHolder())
+    rmg = RequirementsModelGenerator(
+        parent=None,
+        filename=resource_funcname_rootdir_w_path(REQUIREMENTS_YML_FILE),
+        semantic_validator=semantic_validator,
+    )
+
+    model = rmg.requirements_data
+
+    assert model.metadata.title == "Default Title"
+    assert model.imports[0].current_unresolved.version == "9.9.9"
+
+
+def test_requirements_model_generator_unset_env_var_raises(resource_funcname_rootdir_w_path, monkeypatch):
+    monkeypatch.delenv("REQSTOOL_TEST_MAVEN_VERSION", raising=False)
+
+    semantic_validator = SemanticValidator(validation_error_holder=ValidationErrorHolder())
+    with pytest.raises(EnvVarInterpolationError) as exc_info:
+        RequirementsModelGenerator(
+            parent=None,
+            filename=resource_funcname_rootdir_w_path(REQUIREMENTS_YML_FILE),
+            semantic_validator=semantic_validator,
+        )
+
+    assert "REQSTOOL_TEST_MAVEN_VERSION" in str(exc_info.value)


### PR DESCRIPTION
## Summary

Adds environment-variable interpolation to all YAML input (`requirements.yml`, `svcs.yml`, `mvrs.yml`, `annotations.yml`, `reqstool_config.yml`), expanded **before** parsing using POSIX shell parameter expansion (the `envsubst` standard) via the [`expandvars`](https://pypi.org/project/expandvars/) library.

This is the deterministic, principled alternative to `version: latest` (#138). Versions (and tokens, URLs, etc.) can be pinned to env vars and kept current by Renovate, without making ingestion non-deterministic.

Closes #158. Supersedes #138 (closed separately in favour of this approach).

## Syntax (braced form only)

| Syntax | Behaviour |
|---|---|
| `${VAR}` | substitute |
| `${VAR:-default}` | default when unset/empty |
| `${VAR:?message}` | hard-fail with message when unset/empty |
| `${VAR:+alt}` | alt when set |

- A bare `${VAR}` that is unset with no inline default is a **hard error** — keeps ingestion deterministic and surfaces misconfiguration in CI.
- The **bare `$VAR` form is intentionally not expanded.** Every reqstool file carries a `# yaml-language-server: $schema=...` directive (and files may contain regexes, prices, etc.); expanding bare `$` would break all of them. Only `${...}` is interpolated.
- Round-trip (`typ="rt"`) loads backing LSP features are **not** interpolated, so editor positions/diagnostics are unaffected.

## Implementation

- `Utils.interpolate_env_vars(text, source=None)` in `src/reqstool/common/utils.py` — regex-isolates `${...}` spans and runs `expandvars.expand(..., nounset=True)` on each, re-raising as `EnvVarInterpolationError` (new, in `common/exceptions.py`) with the source file in the message.
- Wired into the five safe-load data-ingestion sites (requirements, svcs, mvrs, annotations, reqstool_config generators).
- Added `expandvars==1.1.2` (pure-Python, no transitive deps).
- Docs: new "Environment variable interpolation" section in `usage.adoc`.

## Testing

- Unit tests for substitution, `:-default`, `:?required`, hard-fail on unset, and the `$schema`/bare-`$` no-op.
- End-to-end tests through `RequirementsModelGenerator` (env-var version resolves; unset raises).
- Full suite: **766 passed, 2 skipped** (skips require `GITHUB_TOKEN`). Interpolation is a verified no-op on all existing fixtures. `black` + `flake8` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Scope: `.reqstool-ai.yaml` deliberately excluded

This PR interpolates the requirements **data** files only. `.reqstool-ai.yaml` (read by `reqstool_ai_config.resolve_system_path`, used by `reqstool mcp` / `enrich` auto-detection) is **not** interpolated, by design:

- It holds only a relative `system.path`, already resolved relative to the config file's directory — so `${REPO_ROOT}/...` style roots add nothing.
- It's read inside the reqstool-ai Claude plugin / MCP runtime, where the environment is sparse; hard-fail-on-unset would be a surprising crash there.
- It's auto-discovered by walking up directories (unlike data files you point at explicitly), so interpolation would add a minor ambient-env exposure surface.

If a concrete need arises later, the follow-up is small: interpolate inside `resolve_system_path` **and** catch `EnvVarInterpolationError` there so both `command.py` call sites still emit the graceful `exit(2)` message instead of an unhandled crash.
