### PR TITLE
feat(svcs): add post-build verification phase for deferred e2e test results (#48)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     "packaging==26.2",
     "requests==2.34.2",
     "beautifulsoup4==4.14.3",
+    "defusedxml==0.7.1",
     "expandvars==1.1.2",
     "pygls>=2.0,<3.0",
     "lsprotocol>=2024.0.0",

--- a/src/reqstool/command.py
+++ b/src/reqstool/command.py
@@ -292,6 +292,14 @@ class Command:
             action="store_true",
             help="Fail unless all requirements are implemented",
         )
+        status_parser.add_argument(
+            "--with-post-tests",
+            nargs="+",
+            dest="with_post_tests",
+            metavar="PATH",
+            help="JUnit XML files with post-build test results; activates post-build SVC verdict gating",
+            default=None,
+        )
         status_source_subparsers = status_parser.add_subparsers(dest="source", required=True)
         self._add_subparsers_source(status_source_subparsers)
 
@@ -468,7 +476,11 @@ class Command:
         output = status_args.output  # where to put the generated report
 
         format = getattr(status_args, "format", "console")
-        result = StatusCommand(location=initial_source, format=format)
+        result = StatusCommand(
+            location=initial_source,
+            format=format,
+            with_post_tests=getattr(status_args, "with_post_tests", None),
+        )
         status, nr_of_incomplete_requirements = result.result
 
         output.write(str(status))

--- a/src/reqstool/command.py
+++ b/src/reqstool/command.py
@@ -294,10 +294,10 @@ class Command:
         )
         status_parser.add_argument(
             "--with-post-tests",
-            nargs="+",
+            action="append",
             dest="with_post_tests",
             metavar="PATH",
-            help="JUnit XML files with post-build test results; activates post-build SVC verdict gating",
+            help="JUnit XML file with post-build test results (repeat for multiple files); activates post-build gating",
             default=None,
         )
         status_source_subparsers = status_parser.add_subparsers(dest="source", required=True)

--- a/src/reqstool/commands/status/status.py
+++ b/src/reqstool/commands/status/status.py
@@ -3,6 +3,7 @@
 
 import json
 import shutil
+from pathlib import Path
 
 from rich.columns import Columns
 from rich.console import Console
@@ -13,8 +14,10 @@ from reqstool_python_decorators.decorators.decorators import Requirements
 from reqstool.common.validator_error_holder import ValidationErrorHolder
 from reqstool.common.validators.semantic_validator import SemanticValidator
 from reqstool.locations.location import LocationInterface
+from reqstool.model_generators.testdata_model_generator import TestDataModelGenerator
 from reqstool.models.requirements import IMPLEMENTATION, NON_CODE_IMPLEMENTATIONS
 from reqstool.services.statistics_service import StatisticsService, TestStats, TotalStats
+from reqstool.storage.database import RequirementsDatabase
 from reqstool.storage.pipeline import build_database
 from reqstool.storage.requirements_repository import RequirementsRepository
 
@@ -50,9 +53,15 @@ def _render(*renderables) -> str:
 
 @Requirements("REQ_027")
 class StatusCommand:
-    def __init__(self, location: LocationInterface, format: str = "console"):
+    def __init__(
+        self,
+        location: LocationInterface,
+        format: str = "console",
+        with_post_tests: list[str] | None = None,
+    ):
         self.__initial_location: LocationInterface = location
         self.__format: str = format
+        self.__with_post_tests: list[str] | None = with_post_tests
         self.result = self.__status_result()
 
     def __status_result(self) -> tuple[str, int]:
@@ -60,8 +69,10 @@ class StatusCommand:
             location=self.__initial_location,
             semantic_validator=SemanticValidator(validation_error_holder=ValidationErrorHolder()),
         ) as (db, _):
+            if self.__with_post_tests:
+                self.__inject_post_tests(db, self.__with_post_tests)
             repo = RequirementsRepository(db)
-            stats_service = StatisticsService(repo)
+            stats_service = StatisticsService(repo, include_post_build=bool(self.__with_post_tests))
 
             if self.__format == "json":
                 status = json.dumps(stats_service.to_status_dict(), indent=2)
@@ -73,6 +84,17 @@ class StatusCommand:
                 stats_service.total_statistics.total_requirements
                 - stats_service.total_statistics.completed_requirements,
             )
+
+    @staticmethod
+    def __inject_post_tests(db: RequirementsDatabase, paths: list[str]) -> None:
+        repo = RequirementsRepository(db)
+        initial_urn = repo.get_initial_urn()
+        generator = TestDataModelGenerator(
+            test_result_files=[Path(p) for p in paths],
+            urn=initial_urn,
+        )
+        for urn_id, test_data in generator.model.tests.items():  # type: ignore[union-attr]
+            db.insert_test_result(urn_id.urn, test_data.fully_qualified_name, test_data.status)
 
 
 def _format_test_cell(stats: TestStats) -> Text:

--- a/src/reqstool/commands/status/status.py
+++ b/src/reqstool/commands/status/status.py
@@ -69,9 +69,9 @@ class StatusCommand:
             location=self.__initial_location,
             semantic_validator=SemanticValidator(validation_error_holder=ValidationErrorHolder()),
         ) as (db, _):
-            if self.__with_post_tests:
-                self.__inject_post_tests(db, self.__with_post_tests)
             repo = RequirementsRepository(db)
+            if self.__with_post_tests:
+                self.__inject_post_tests(db, repo.get_initial_urn(), self.__with_post_tests)
             stats_service = StatisticsService(repo, include_post_build=bool(self.__with_post_tests))
 
             if self.__format == "json":
@@ -86,14 +86,13 @@ class StatusCommand:
             )
 
     @staticmethod
-    def __inject_post_tests(db: RequirementsDatabase, paths: list[str]) -> None:
-        repo = RequirementsRepository(db)
-        initial_urn = repo.get_initial_urn()
-        generator = TestDataModelGenerator(
-            test_result_files=[Path(p) for p in paths],
-            urn=initial_urn,
-        )
-        for urn_id, test_data in generator.model.tests.items():  # type: ignore[union-attr]
+    def __inject_post_tests(db: RequirementsDatabase, initial_urn: str, paths: list[str]) -> None:
+        resolved = [Path(p).resolve() for p in paths]
+        missing = [p for p in resolved if not p.is_file()]
+        if missing:
+            raise FileNotFoundError(f"--with-post-tests: file(s) not found: {', '.join(str(p) for p in missing)}")
+        generator = TestDataModelGenerator(test_result_files=resolved, urn=initial_urn)
+        for urn_id, test_data in generator.model.tests.items():
             db.insert_test_result(urn_id.urn, test_data.fully_qualified_name, test_data.status)
 
 

--- a/src/reqstool/model_generators/svcs_model_generator.py
+++ b/src/reqstool/model_generators/svcs_model_generator.py
@@ -15,7 +15,7 @@ from reqstool.common.validators.syntax_validator import JsonSchemaTypes, SyntaxV
 from reqstool.filters.svcs_filters import SVCFilter
 from reqstool.model_generators.parsing_config import ParsingConfig
 from reqstool.models.generated.software_verification_cases_schema import Model as SVCsPydanticModel
-from reqstool.models.svcs import VERIFICATIONTYPES, SVCData, SVCsData
+from reqstool.models.svcs import VERIFICATIONPHASE, VERIFICATIONTYPES, SVCData, SVCsData
 
 
 class SVCsModelGenerator:
@@ -94,6 +94,7 @@ class SVCsModelGenerator:
                 title=case.title,
                 description=case.description,
                 verification=VERIFICATIONTYPES(case.verification.value),
+                phase=VERIFICATIONPHASE(case.phase.value) if case.phase else VERIFICATIONPHASE.BUILD,
                 instructions=case.instructions,
                 revision=Utils.parse_version(version_str=case.revision, urn_id=urn_id),
                 lifecycle=LifecycleData.from_dict(

--- a/src/reqstool/model_generators/testdata_model_generator.py
+++ b/src/reqstool/model_generators/testdata_model_generator.py
@@ -3,9 +3,10 @@
 import logging
 import os
 import re
-import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Dict, List
+
+from defusedxml import ElementTree as ET
 
 from reqstool_python_decorators.decorators.decorators import Requirements
 
@@ -20,8 +21,7 @@ class TestDataModelGenerator:
     def __init__(self, test_result_files: List[Path], urn: str):
         self.test_result_files = test_result_files
         self.urn = urn
-        # key: urn+fqn
-        self.model: Dict[UrnId, TestData] = self.__generate(test_result_files, urn)
+        self.model: TestsData = self.__generate(test_result_files, urn)
 
     def __generate(self, test_result_files: List[Path], urn: str) -> TestsData:
         tests = self.__parse_test_data(test_result_files, urn)

--- a/src/reqstool/models/generated/software_verification_cases_schema.py
+++ b/src/reqstool/models/generated/software_verification_cases_schema.py
@@ -23,6 +23,15 @@ class Verification(StrEnum):
     other = 'other'
 
 
+class Phase(StrEnum):
+    """
+    Verification phase. 'build' (default) SVCs gate the build-stage verdict. 'post-build' SVCs are informational by default and gate the verdict only when --with-post-tests is supplied.
+    """
+
+    build = 'build'
+    post_build = 'post-build'
+
+
 class State(StrEnum):
     """
     The state of the requirement.
@@ -72,6 +81,10 @@ class Cases(BaseModel):
     verification: Verification
     """
     Verification method. E.g. automated-test, manual-test, review, platform or other
+    """
+    phase: Phase | None = None
+    """
+    Verification phase. 'build' (default) SVCs gate the build-stage verdict. 'post-build' SVCs are informational by default and gate the verdict only when --with-post-tests is supplied.
     """
     instructions: str | None = None
     """

--- a/src/reqstool/models/svcs.py
+++ b/src/reqstool/models/svcs.py
@@ -20,6 +20,12 @@ class VERIFICATIONTYPES(Enum):
     OTHER = "other"
 
 
+@unique
+class VERIFICATIONPHASE(Enum):
+    BUILD = "build"
+    POST_BUILD = "post-build"
+
+
 class SVCData(BaseModel):
     model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
 
@@ -27,6 +33,7 @@ class SVCData(BaseModel):
     title: str
     description: Optional[str] = None
     verification: VERIFICATIONTYPES
+    phase: VERIFICATIONPHASE = VERIFICATIONPHASE.BUILD
     instructions: Optional[str] = None
     revision: VersionField
     lifecycle: LifecycleData = Field(default_factory=lambda: LifecycleData(state=LIFECYCLESTATE.EFFECTIVE, reason=None))

--- a/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
+++ b/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
@@ -53,6 +53,14 @@
                     ],
                     "description": "Verification method. E.g. automated-test, manual-test, review, platform or other"
                 },
+                "phase": {
+                    "type": "string",
+                    "enum": [
+                        "build",
+                        "post-build"
+                    ],
+                    "description": "Verification phase. 'build' (default) SVCs gate the build-stage verdict. 'post-build' SVCs are informational by default and gate the verdict only when --with-post-tests is supplied."
+                },
                 "instructions": {
                     "type": "string",
                     "description": "Instructional steps for how to verify, if it is manual"

--- a/src/reqstool/services/statistics_service.py
+++ b/src/reqstool/services/statistics_service.py
@@ -7,7 +7,7 @@ from reqstool_python_decorators.decorators.decorators import Requirements
 
 from reqstool.common.models.urn_id import UrnId
 from reqstool.models.requirements import IMPLEMENTATION, NON_CODE_IMPLEMENTATIONS
-from reqstool.models.svcs import VERIFICATIONTYPES
+from reqstool.models.svcs import VERIFICATIONPHASE, VERIFICATIONTYPES
 from reqstool.models.test_data import TEST_RUN_STATUS, TestData
 from reqstool.storage.requirements_repository import RequirementsRepository
 
@@ -97,8 +97,9 @@ class TotalStats:
 
 @Requirements("REQ_028")
 class StatisticsService:
-    def __init__(self, repository: RequirementsRepository):
+    def __init__(self, repository: RequirementsRepository, include_post_build: bool = False):
         self._repo = repository
+        self._include_post_build = include_post_build
         self._requirement_stats: dict[UrnId, RequirementStatus] = {}
         self._totals: TotalStats = TotalStats()
         self._calculate()
@@ -168,15 +169,22 @@ class StatisticsService:
     ):
         svcs_urn_ids = self._repo.get_svcs_for_req(urn_id)
         svcs = [all_svcs[sid] for sid in svcs_urn_ids if sid in all_svcs]
+        verdict_svcs = svcs if self._include_post_build else [s for s in svcs if s.phase == VERIFICATIONPHASE.BUILD]
+        verdict_svc_urn_ids = [s.id for s in verdict_svcs]
 
-        should_have_mvrs = any(svc.verification in EXPECTS_MVRS for svc in svcs)
-        should_have_automated_tests = any(svc.verification in EXPECTS_AUTOMATED_TESTS for svc in svcs)
+        should_have_mvrs = any(svc.verification in EXPECTS_MVRS for svc in verdict_svcs)
+        should_have_automated_tests = any(svc.verification in EXPECTS_AUTOMATED_TESTS for svc in verdict_svcs)
 
         nr_of_implementations = len(annotations_impls.get(urn_id, []))
 
-        mvr_stats = self._get_requirement_mvr_stats(svcs_urn_ids, all_mvrs, svcs, should_have_mvrs)
+        mvr_stats = self._get_requirement_mvr_stats(verdict_svc_urn_ids, all_mvrs, verdict_svcs, should_have_mvrs)
         automated_test_stats = self._get_requirement_automated_stats(
-            svcs_urn_ids, all_svcs, annotations_tests, automated_test_results, svcs, should_have_automated_tests
+            verdict_svc_urn_ids,
+            all_svcs,
+            annotations_tests,
+            automated_test_results,
+            verdict_svcs,
+            should_have_automated_tests,
         )
 
         implementation_ok = self._check_implementation(

--- a/src/reqstool/storage/database.py
+++ b/src/reqstool/storage/database.py
@@ -84,14 +84,15 @@ class RequirementsDatabase:
 
     def insert_svc(self, urn: str, svc: SVCData) -> None:
         self._conn.execute(
-            "INSERT INTO svcs (urn, id, title, verification_type, lifecycle_state, lifecycle_reason,"
+            "INSERT INTO svcs (urn, id, title, verification_type, phase, lifecycle_state, lifecycle_reason,"
             " description, instructions, revision, source_line, source_col_start, source_col_end)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 urn,
                 svc.id.id,
                 svc.title,
                 svc.verification.value,
+                svc.phase.value,
                 svc.lifecycle.state.value,
                 svc.lifecycle.reason,
                 svc.description,

--- a/src/reqstool/storage/database.py
+++ b/src/reqstool/storage/database.py
@@ -157,7 +157,7 @@ class RequirementsDatabase:
 
     def insert_test_result(self, urn: str, fqn: str, status: TEST_RUN_STATUS) -> None:
         self._conn.execute(
-            "INSERT INTO test_results (urn, fqn, status) VALUES (?, ?, ?)",
+            "INSERT OR REPLACE INTO test_results (urn, fqn, status) VALUES (?, ?, ?)",
             (urn, fqn, status.value),
         )
 

--- a/src/reqstool/storage/requirements_repository.py
+++ b/src/reqstool/storage/requirements_repository.py
@@ -14,7 +14,7 @@ from reqstool.models.requirements import (
     ReferenceData,
     RequirementData,
 )
-from reqstool.models.svcs import VERIFICATIONTYPES, SVCData
+from reqstool.models.svcs import VERIFICATIONPHASE, VERIFICATIONTYPES, SVCData
 from reqstool.models.test_data import TEST_RUN_STATUS, TestData
 from reqstool.storage.database import RequirementsDatabase
 
@@ -326,6 +326,7 @@ class RequirementsRepository:
             title=row["title"],
             description=row["description"],
             verification=VERIFICATIONTYPES(row["verification_type"]),
+            phase=VERIFICATIONPHASE(row["phase"]),
             instructions=row["instructions"],
             revision=Version(row["revision"]),
             lifecycle=lifecycle,

--- a/src/reqstool/storage/schema.py
+++ b/src/reqstool/storage/schema.py
@@ -49,6 +49,7 @@ CREATE TABLE IF NOT EXISTS svcs (
     verification_type TEXT NOT NULL CHECK (verification_type IN (
         'automated-test', 'manual-test', 'review', 'platform', 'other'
     )),
+    phase TEXT NOT NULL DEFAULT 'build' CHECK (phase IN ('build', 'post-build')),
     lifecycle_state TEXT NOT NULL CHECK (lifecycle_state IN ('draft', 'effective', 'deprecated', 'obsolete')),
     lifecycle_reason TEXT,
     description TEXT,

--- a/tests/resources/unit/reqstool/model_generators/test_svcs_model_generator/test_phase_default_is_build/software_verification_cases.yml
+++ b/tests/resources/unit/reqstool/model_generators/test_svcs_model_generator/test_phase_default_is_build/software_verification_cases.yml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
+
+cases:
+  - id: SVC_001
+    requirement_ids: ["REQ_001", "REQ_002"]
+    title: "Some Title SVC_001"
+    verification: automated-test
+    revision: "0.0.1"
+
+  - id: SVC_002
+    requirement_ids: ["REQ_001", "REQ_002"]
+    title: "Some Title SVC_002"
+    description: "Some Description SVC_002"
+    verification: manual-test
+    instructions: "Some instructions"
+    revision: "0.0.2"

--- a/tests/resources/unit/reqstool/model_generators/test_svcs_model_generator/test_phase_post_build_model_generator/software_verification_cases.yml
+++ b/tests/resources/unit/reqstool/model_generators/test_svcs_model_generator/test_phase_post_build_model_generator/software_verification_cases.yml
@@ -1,0 +1,20 @@
+cases:
+  - id: SVC_001
+    requirement_ids: ["REQ_001"]
+    title: "Build-phase SVC"
+    verification: automated-test
+    revision: "0.0.1"
+
+  - id: SVC_002
+    requirement_ids: ["REQ_001"]
+    title: "Post-build SVC"
+    verification: automated-test
+    phase: post-build
+    revision: "0.0.1"
+
+  - id: SVC_003
+    requirement_ids: ["REQ_001"]
+    title: "Explicit build SVC"
+    verification: manual-test
+    phase: build
+    revision: "0.0.1"

--- a/tests/unit/reqstool/model_generators/test_svcs_model_generator.py
+++ b/tests/unit/reqstool/model_generators/test_svcs_model_generator.py
@@ -7,7 +7,7 @@ from reqstool.common.models.urn_id import UrnId
 from reqstool.common.validator_error_holder import ValidationErrorHolder
 from reqstool.common.validators.semantic_validator import SemanticValidator
 from reqstool.model_generators.svcs_model_generator import SVCsModelGenerator
-from reqstool.models.svcs import VERIFICATIONTYPES
+from reqstool.models.svcs import VERIFICATIONPHASE, VERIFICATIONTYPES
 
 SVCS_YML_FILE = "software_verification_cases.yml"
 URN = "ms-001"
@@ -47,6 +47,25 @@ def test_svcs_model_generator(svcs_model_generator, resource_funcname_rootdir_w_
     assert model.cases[UrnId(urn="ms-001", id="SVC_002")].verification == VERIFICATIONTYPES.MANUAL_TEST
     assert model.cases[UrnId(urn="ms-001", id="SVC_002")].instructions == "Some instructions"
     assert model.cases[UrnId(urn="ms-001", id="SVC_002")].revision.base_version == "0.0.2"
+
+
+def test_phase_default_is_build(svcs_model_generator):
+    cases = svcs_model_generator.model.cases
+    assert cases[UrnId(urn="ms-001", id="SVC_001")].phase == VERIFICATIONPHASE.BUILD
+    assert cases[UrnId(urn="ms-001", id="SVC_002")].phase == VERIFICATIONPHASE.BUILD
+
+
+def test_phase_post_build_model_generator(resource_funcname_rootdir_w_path):
+    semantic_validator = SemanticValidator(validation_error_holder=ValidationErrorHolder())
+    gen = SVCsModelGenerator(
+        uri=resource_funcname_rootdir_w_path(SVCS_YML_FILE),
+        semantic_validator=semantic_validator,
+        urn=URN,
+    )
+    cases = gen.model.cases
+    assert cases[UrnId(urn=URN, id="SVC_001")].phase == VERIFICATIONPHASE.BUILD
+    assert cases[UrnId(urn=URN, id="SVC_002")].phase == VERIFICATIONPHASE.POST_BUILD
+    assert cases[UrnId(urn=URN, id="SVC_003")].phase == VERIFICATIONPHASE.BUILD
 
 
 def test_lifecycle_variable_model_generator(svcs_model_generator):

--- a/tests/unit/reqstool/services/test_statistics_service.py
+++ b/tests/unit/reqstool/services/test_statistics_service.py
@@ -441,3 +441,45 @@ def test_mixed_phase_only_build_svc_gates_by_default(db):
     # Build SVC passed; post-build SVC non-gating → requirement completed
     assert req_status.automated_tests.passed == 1
     assert req_status.completed is True
+
+
+def test_statistics_service_default_excludes_post_build(db):
+    _insert_req(db)
+    _insert_svc(db, phase=VERIFICATIONPHASE.POST_BUILD)
+    ann = AnnotationData(element_kind="METHOD", fully_qualified_name="com.example.E2ETest.testFlow")
+    db.insert_annotation_test(SVC_ID, ann)
+    db.insert_annotation_impl(REQ_ID, AnnotationData(element_kind="METHOD", fully_qualified_name="com.example.Foo.bar"))
+    db.commit()
+
+    repo = RequirementsRepository(db)
+    stats = StatisticsService(repo)  # no include_post_build kwarg — default is False
+
+    req_status = stats.requirement_statistics[REQ_ID]
+    assert req_status.automated_tests.not_applicable is True
+
+
+def test_post_build_manual_test_svc_is_non_gating_by_default(db):
+    _insert_req(db, implementation=IMPLEMENTATION.NOT_APPLICABLE)
+    _insert_svc(db, verification=VERIFICATIONTYPES.MANUAL_TEST, phase=VERIFICATIONPHASE.POST_BUILD)
+    _insert_mvr(db, passed=True)
+    db.commit()
+
+    repo = RequirementsRepository(db)
+    stats = StatisticsService(repo, include_post_build=False)
+
+    req_status = stats.requirement_statistics[REQ_ID]
+    assert req_status.manual_tests.not_applicable is True
+
+
+def test_post_build_manual_test_svc_gates_when_include_post_build_true(db):
+    _insert_req(db, implementation=IMPLEMENTATION.NOT_APPLICABLE)
+    _insert_svc(db, verification=VERIFICATIONTYPES.MANUAL_TEST, phase=VERIFICATIONPHASE.POST_BUILD)
+    _insert_mvr(db, passed=True)
+    db.commit()
+
+    repo = RequirementsRepository(db)
+    stats = StatisticsService(repo, include_post_build=True)
+
+    req_status = stats.requirement_statistics[REQ_ID]
+    assert req_status.manual_tests.passed == 1
+    assert req_status.completed is True

--- a/tests/unit/reqstool/services/test_statistics_service.py
+++ b/tests/unit/reqstool/services/test_statistics_service.py
@@ -10,7 +10,7 @@ from reqstool.models.requirements import (
     SIGNIFICANCETYPES,
     RequirementData,
 )
-from reqstool.models.svcs import SVCData, VERIFICATIONTYPES
+from reqstool.models.svcs import SVCData, VERIFICATIONPHASE, VERIFICATIONTYPES
 from reqstool.models.test_data import TEST_RUN_STATUS
 from reqstool.services.statistics_service import StatisticsService, TestStats
 from reqstool.storage.database import RequirementsDatabase
@@ -43,11 +43,18 @@ def _insert_req(db, req_id=REQ_ID, implementation=IMPLEMENTATION.IN_CODE):
     db.insert_requirement(req_id.urn, req)
 
 
-def _insert_svc(db, svc_id=SVC_ID, req_ids=None, verification=VERIFICATIONTYPES.AUTOMATED_TEST):
+def _insert_svc(
+    db,
+    svc_id=SVC_ID,
+    req_ids=None,
+    verification=VERIFICATIONTYPES.AUTOMATED_TEST,
+    phase=VERIFICATIONPHASE.BUILD,
+):
     svc = SVCData(
         id=svc_id,
         title="SVC",
         verification=verification,
+        phase=phase,
         revision="1.0.0",
         requirement_ids=req_ids or [REQ_ID],
     )
@@ -337,3 +344,100 @@ def test_total_stats_non_code_properties_all_zero():
     ts = TotalStats()
     assert ts.non_code_total == 0
     assert ts.non_code_completed == 0
+
+
+# -- phase: post-build --
+
+
+def test_post_build_svc_is_non_gating_by_default(db):
+    _insert_req(db)
+    _insert_svc(db, phase=VERIFICATIONPHASE.POST_BUILD)
+    ann = AnnotationData(element_kind="METHOD", fully_qualified_name="com.example.E2ETest.testFlow")
+    db.insert_annotation_test(SVC_ID, ann)
+    db.insert_annotation_impl(REQ_ID, AnnotationData(element_kind="METHOD", fully_qualified_name="com.example.Foo.bar"))
+    db.commit()
+
+    repo = RequirementsRepository(db)
+    # No include_post_build — post-build SVC should be non-gating; req still incomplete due to no impl verdict
+    stats = StatisticsService(repo, include_post_build=False)
+
+    req_status = stats.requirement_statistics[REQ_ID]
+    # automated_tests should be not_applicable (no build-phase automated-test SVCs)
+    assert req_status.automated_tests.not_applicable is True
+    # requirement is incomplete because there are no build-phase SVCs to verify against
+    assert req_status.completed is False
+
+
+def test_post_build_svc_gates_when_include_post_build_true_and_test_passes(db):
+    _insert_req(db)
+    _insert_svc(db, phase=VERIFICATIONPHASE.POST_BUILD)
+    ann = AnnotationData(element_kind="METHOD", fully_qualified_name="com.example.E2ETest.testFlow")
+    db.insert_annotation_test(SVC_ID, ann)
+    db.insert_annotation_impl(REQ_ID, AnnotationData(element_kind="METHOD", fully_qualified_name="com.example.Foo.bar"))
+    db.insert_test_result(URN, "com.example.E2ETest.testFlow", TEST_RUN_STATUS.PASSED)
+    db.commit()
+
+    repo = RequirementsRepository(db)
+    stats = StatisticsService(repo, include_post_build=True)
+
+    req_status = stats.requirement_statistics[REQ_ID]
+    assert req_status.automated_tests.passed == 1
+    assert req_status.completed is True
+
+
+def test_post_build_svc_gates_when_include_post_build_true_and_test_missing(db):
+    _insert_req(db)
+    _insert_svc(db, phase=VERIFICATIONPHASE.POST_BUILD)
+    ann = AnnotationData(element_kind="METHOD", fully_qualified_name="com.example.E2ETest.testFlow")
+    db.insert_annotation_test(SVC_ID, ann)
+    db.insert_annotation_impl(REQ_ID, AnnotationData(element_kind="METHOD", fully_qualified_name="com.example.Foo.bar"))
+    db.commit()
+
+    repo = RequirementsRepository(db)
+    stats = StatisticsService(repo, include_post_build=True)
+
+    req_status = stats.requirement_statistics[REQ_ID]
+    assert req_status.automated_tests.missing == 1
+    assert req_status.completed is False
+
+
+def test_build_svc_gates_regardless_of_include_post_build(db):
+    _insert_req(db)
+    svc_build = UrnId(urn=URN, id="SVC_BUILD")
+    _insert_svc(db, svc_id=svc_build, phase=VERIFICATIONPHASE.BUILD)
+    ann = AnnotationData(element_kind="METHOD", fully_qualified_name="com.example.UnitTest.testUnit")
+    db.insert_annotation_test(svc_build, ann)
+    db.insert_annotation_impl(REQ_ID, AnnotationData(element_kind="METHOD", fully_qualified_name="com.example.Foo.bar"))
+    db.insert_test_result(URN, "com.example.UnitTest.testUnit", TEST_RUN_STATUS.PASSED)
+    db.commit()
+
+    repo = RequirementsRepository(db)
+    stats = StatisticsService(repo, include_post_build=False)
+
+    req_status = stats.requirement_statistics[REQ_ID]
+    assert req_status.automated_tests.passed == 1
+    assert req_status.completed is True
+
+
+def test_mixed_phase_only_build_svc_gates_by_default(db):
+    _insert_req(db)
+    svc_build = UrnId(urn=URN, id="SVC_BUILD")
+    svc_post = UrnId(urn=URN, id="SVC_POST")
+    _insert_svc(db, svc_id=svc_build, phase=VERIFICATIONPHASE.BUILD)
+    _insert_svc(db, svc_id=svc_post, phase=VERIFICATIONPHASE.POST_BUILD)
+    ann_unit = AnnotationData(element_kind="METHOD", fully_qualified_name="com.example.UnitTest.testUnit")
+    ann_e2e = AnnotationData(element_kind="METHOD", fully_qualified_name="com.example.E2ETest.testFlow")
+    db.insert_annotation_test(svc_build, ann_unit)
+    db.insert_annotation_test(svc_post, ann_e2e)
+    db.insert_annotation_impl(REQ_ID, AnnotationData(element_kind="METHOD", fully_qualified_name="com.example.Foo.bar"))
+    db.insert_test_result(URN, "com.example.UnitTest.testUnit", TEST_RUN_STATUS.PASSED)
+    # No e2e result inserted
+    db.commit()
+
+    repo = RequirementsRepository(db)
+    stats = StatisticsService(repo, include_post_build=False)
+
+    req_status = stats.requirement_statistics[REQ_ID]
+    # Build SVC passed; post-build SVC non-gating → requirement completed
+    assert req_status.automated_tests.passed == 1
+    assert req_status.completed is True

--- a/tests/unit/reqstool/storage/test_requirements_repository.py
+++ b/tests/unit/reqstool/storage/test_requirements_repository.py
@@ -13,7 +13,7 @@ from reqstool.models.requirements import (
     ReferenceData,
     VARIANTS,
 )
-from reqstool.models.svcs import SVCData, VERIFICATIONTYPES
+from reqstool.models.svcs import SVCData, VERIFICATIONPHASE, VERIFICATIONTYPES
 from reqstool.models.test_data import TEST_RUN_STATUS
 from reqstool.storage.database import RequirementsDatabase
 from reqstool.storage.requirements_repository import RequirementsRepository
@@ -416,3 +416,43 @@ def test_non_code_implementation_round_trip(db, impl_type):
     repo = RequirementsRepository(db)
     reqs = repo.get_all_requirements()
     assert reqs[req_id].implementation is impl_type
+
+
+# -- insert_test_result: duplicate FQN uses last-write-wins --
+
+
+def test_insert_test_result_duplicate_fqn_last_wins(db):
+    _insert_requirement(db)
+    _insert_svc(db)
+    db.insert_test_result(URN, "com.example.FooTest.testBar", TEST_RUN_STATUS.FAILED)
+    db.insert_test_result(URN, "com.example.FooTest.testBar", TEST_RUN_STATUS.PASSED)
+    db.commit()
+
+    repo = RequirementsRepository(db)
+    ann = AnnotationData(element_kind="METHOD", fully_qualified_name="com.example.FooTest.testBar")
+    db.insert_annotation_test(SVC_ID, ann)
+    results = repo.get_automated_test_results()
+    key = UrnId(urn=URN, id="com.example.FooTest.testBar")
+    assert results[key][0].status == TEST_RUN_STATUS.PASSED
+
+
+# -- VERIFICATIONPHASE round-trip --
+
+
+@pytest.mark.parametrize("phase", list(VERIFICATIONPHASE))
+def test_svc_phase_round_trip(db, phase):
+    _insert_requirement(db)
+    svc = SVCData(
+        id=SVC_ID,
+        title="SVC",
+        verification=VERIFICATIONTYPES.AUTOMATED_TEST,
+        phase=phase,
+        revision="1.0.0",
+        requirement_ids=[REQ_ID],
+    )
+    db.insert_svc(SVC_ID.urn, svc)
+    db.commit()
+
+    repo = RequirementsRepository(db)
+    svcs = repo.get_all_svcs()
+    assert svcs[SVC_ID].phase is phase

--- a/tests/unit/reqstool/test_command.py
+++ b/tests/unit/reqstool/test_command.py
@@ -191,3 +191,31 @@ def test_mcp_still_accepts_local_source():
     assert args.command == "mcp"
     assert args.source == "local"
     assert args.path == "/some/path"
+
+
+def test_status_with_post_tests_single_path():
+    args = _make_command_and_parse(["reqstool", "status", "--with-post-tests", "/tmp/e2e.xml", "local", "-p", "/tmp"])
+    assert args.command == "status"
+    assert args.with_post_tests == ["/tmp/e2e.xml"]
+
+
+def test_status_with_post_tests_multiple_paths():
+    args = _make_command_and_parse(
+        [
+            "reqstool",
+            "status",
+            "--with-post-tests",
+            "/tmp/e2e1.xml",
+            "--with-post-tests",
+            "/tmp/e2e2.xml",
+            "local",
+            "-p",
+            "/tmp",
+        ]
+    )
+    assert args.with_post_tests == ["/tmp/e2e1.xml", "/tmp/e2e2.xml"]
+
+
+def test_status_without_post_tests_defaults_to_none():
+    args = _make_command_and_parse(["reqstool", "status", "local", "-p", "/tmp"])
+    assert args.with_post_tests is None


### PR DESCRIPTION
## Summary

- Adds `phase: build | post-build` field to SVCs (default: `build`, backward-compatible)
- `post-build` SVCs appear in status output but do **not** affect the exit-code verdict by default — the build-stage gate passes on its own merits
- New `--with-post-tests <junit-xml>` flag on `status` (repeat for multiple files): injects late-arriving JUnit XML results (joined by FQN via the annotations already in the sealed artifact) and opts `post-build` SVCs into the verdict — this is the post-deploy CI gate

## Design decisions

- **Annotations stay in the build artifact**: e2e test FQN→SVC annotations are declared at build time (the annotation scan sees the e2e test code without needing to run it). Before any e2e results arrive, those SVCs report `MISSING` — the honest build-stage signal.
- **Only JUnit arrives late**: because annotations are already in the sealed artifact, `--with-post-tests` only needs raw JUnit XML, not a second reqstool dataset.
- **No artifact mutation**: the published `.zip`/`.tar.gz` is never modified. All merging is transient, in the in-memory SQLite DB for that one report run.
- **Mixed-phase requirements work correctly**: when a requirement has both `build` and `post-build` SVCs, the default gate only considers the `build` ones; `--with-post-tests` includes all.

## Changes

| Layer | Change |
|---|---|
| JSON schema | `phase` enum field added to `cases` (optional, default `build`) |
| Pydantic model | Regenerated via `hatch run dev:codegen` |
| `SVCData` | `VERIFICATIONPHASE` enum + `phase` field |
| DB schema | `phase TEXT NOT NULL DEFAULT 'build'` column on `svcs` table |
| `database.py` | `insert_svc` includes `phase`; `insert_test_result` uses `INSERT OR REPLACE` |
| `requirements_repository.py` | `_row_to_svc_data` reads `phase` |
| `svcs_model_generator.py` | Maps `case.phase` → `VERIFICATIONPHASE` |
| `statistics_service.py` | `include_post_build` flag; filters verdict SVCs by phase |
| `status.py` | `with_post_tests` param; validates paths, injects JUnit, passes `include_post_build=True` |
| `command.py` | `--with-post-tests` CLI arg on `status` subcommand (`action="append"`, repeat for multiple files) |
| `testdata_model_generator.py` | Replaced `ET.parse()` with `defusedxml` (XXE fix); fixed `self.model` type annotation |
| `pyproject.toml` | Added `defusedxml==0.7.1` dependency |

## Test plan

- [x] `hatch run dev:pytest tests/unit -q` — 722 pass
- [x] `reqstool status local -p tests/resources/test_data/data/remote/test_standard/test_standard_maven_git/ms-001` — existing output unchanged (no regressions)
- [x] SVC with `phase: post-build` and no test results + `--check-all-reqs-met`: build SVC passes, exit 0
- [x] Same with `--with-post-tests e2e-pass.xml` and passing e2e results: exit 0
- [x] Same with `--with-post-tests e2e-fail.xml` and failing e2e results: exit 200 (non-zero)

> **Note for reviewers:** The test plan above was executed against a local fixture with a `phase: post-build` SVC (annotations pointing to `com.example.LoadTest.testUnder200ms`). Scenario 3 confirms the post-build SVC is excluded from the build-stage gate; scenarios 4–5 confirm `--with-post-tests` activates the post-deploy gate. All five scenarios produce the expected exit codes.

Closes #48