### PR TITLE
feat(mvrs): add MVR supersession, latest dated MVR per SVC determines verdict

### DIFF
--- a/docs/modules/ROOT/pages/how_it_works.adoc
+++ b/docs/modules/ROOT/pages/how_it_works.adoc
@@ -36,6 +36,16 @@ For each implementation node, `requirements.yml` is parsed (validation runs) but
 
 NOTE: `imports:` sections of implementation nodes are not followed — an implementation's own imports belong to a different scope.
 
+== MVR verdict and supersession
+
+`StatisticsService` computes the manual-test verdict for each SVC by calling `RequirementsRepository.get_effective_mvr_for_svc()`.
+When a SVC has multiple MVRs, the one with the *latest `date`* (UTC-normalised via SQLite's `datetime()` function so mixed timezone offsets compare correctly) is the verdict; all others are superseded.
+When a SVC has only one MVR — dated or undated — that entry is always the verdict.
+
+The global totals (`total_manual_tests`, `passed_manual_tests`, `failed_manual_tests`) are computed in a single SQL aggregation query and count one effective verdict per SVC, never superseded entries.
+
+See xref:usage.adoc#mvr-supersession[MVR supersession] for the YAML format rules and examples.
+
 == The `variant` field
 
 `variant: system/microservice/external` in `requirements.yml` is optional advisory metadata. It is not a behavioral gate — parsing is entirely presence-based. If a file exists, it is read. If a section exists in YAML, it is parsed.

--- a/docs/modules/ROOT/pages/lsp.adoc
+++ b/docs/modules/ROOT/pages/lsp.adoc
@@ -246,11 +246,11 @@ The full protocol spec (OpenRPC) is at `docs/modules/ROOT/lsp/reqstool-lsp.openr
 
 | `svc`
 | `SVC_001`
-| Full SVC with linked requirements, test annotations, test results, and MVRs
+| Full SVC with linked requirements, test annotations, test results, and MVRs (each with `date` and `superseded` flag)
 
 | `mvr`
 | `MVR_001`
-| Manual verification result with linked SVC IDs
+| Manual verification result with linked SVC IDs, RFC 3339 date, and `superseded` flag
 
 | `urn`
 | `my-service`

--- a/docs/modules/ROOT/pages/mcp.adoc
+++ b/docs/modules/ROOT/pages/mcp.adoc
@@ -131,6 +131,9 @@ Full details for a single SVC.
 
 *Returns:* `{ type, id, urn, title, description, verification, instructions, revision, lifecycle, requirement_ids, test_annotations, test_results, test_summary, mvrs, location, source_paths }`
 
+Each entry in `mvrs` is `{ id, urn, passed, date, comment, superseded }`.
+`date` is an RFC 3339 date-time string or empty string; `superseded: true` means an older entry that was superseded by a later one.
+
 ==== `get_mvr`
 
 Full details for a single MVR.
@@ -139,7 +142,9 @@ Full details for a single MVR.
 
 * `id` _(string, required)_
 
-*Returns:* `{ type, id, urn, passed, comment, svc_ids, location, source_paths }`
+*Returns:* `{ type, id, urn, passed, date, comment, svc_ids, location, source_paths }`
+
+`date` is an RFC 3339 date-time string, or an empty string if the MVR has no date.
 
 ==== `get_urn_details`
 

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -148,7 +148,7 @@ results:
 
 *`date` field rules:*
 
-* The `date` value must be a *timezone-aware ISO 8601 date-time* (RFC 3339), for example `"2026-01-15T14:30:00Z"` or `"2026-01-15T14:30:00+01:00"`. Note the required quotes — unquoted dates are parsed by YAML as `date` objects, not strings.
+* The `date` value must be an *RFC 3339 date-time*, for example `"2026-01-15T14:30:00Z"` or `"2026-01-15T14:30:00+01:00"`. A timezone offset is mandatory — bare local datetimes without a timezone are rejected. Note the required quotes — unquoted values are parsed by YAML as `date` objects, not strings.
 * `date` is *optional* when only one MVR references a given SVC; the single entry is always the verdict regardless.
 * `date` is *required* on every MVR that references a given SVC as soon as more than one MVR does. A missing `date` in that situation is a semantic validation error.
 * Two MVRs for the same SVC with the *exact same UTC moment* are a validation error — add a time component to disambiguate (e.g. `T09:00:00Z` vs `T14:30:00Z`).

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -108,7 +108,8 @@ The requirements table shows for each requirement:
 ** `framework` -- `framework`: fulfilled by framework auto-configuration (Spring Boot starters, OTel agents); no annotation required
 ** `N/A` -- not applicable, intentionally deferred, or out of scope; no annotation required
 * *Automated Tests* -- test results from JUnit XML: T=total SVCs, P=passed, F=failed, S=skipped, M=missing (no test found for SVC)
-* *Manual Tests* -- manual verification results: T=total, P=passed, F=failed, M=missing
+* *Manual Tests* -- manual verification results: T=total, P=passed, F=failed, M=missing.
+When multiple MVRs exist for the same SVC, only the one with the latest `date` counts (supersession); older ones are retained as audit history in the report but excluded from the verdict.
 
 The summary panels below the table break down requirements by implementation type.
 The `In Code` panel shows total, verified, annotated-not-verified, and missing-annotation counts (all percentages relative to in-code requirements).
@@ -119,6 +120,38 @@ The `N/A`, `Configuration`, `Platform`, and `Framework` panels each show three c
 * *Not Verified* -- count not yet verified, as a percentage of _this type_
 
 The exit code equals the number of unmet requirements, making it suitable for CI/CD gates (`exit 0` = all requirements met).
+
+[[mvr-supersession]]
+=== MVR supersession
+
+When a manual verification is repeated (for example, a first attempt fails and a corrected one passes), add both results as separate MVR entries and set a `date` on each.
+Reqstool selects the entry with the *latest date* as the effective verdict for that SVC.
+Older entries are retained as audit history and shown with a `(superseded)` marker in the report, but are excluded from the pass/fail computation.
+
+[source,yaml]
+----
+results:
+  - id: MVR_001
+    svc_ids: ["SVC_021"]
+    date: "2026-01-10T09:00:00Z"   # <1>
+    pass: false
+    comment: "XSD validation failed."
+
+  - id: MVR_002
+    svc_ids: ["SVC_021"]
+    date: "2026-01-15T14:30:00Z"   # <2>
+    pass: true
+    comment: "All fields present."
+----
+<1> Older entry — superseded, shown as history in the report.
+<2> Latest entry — effective verdict; this determines pass/fail.
+
+*`date` field rules:*
+
+* The `date` value must be a *timezone-aware ISO 8601 date-time* (RFC 3339), for example `"2026-01-15T14:30:00Z"` or `"2026-01-15T14:30:00+01:00"`. Note the required quotes — unquoted dates are parsed by YAML as `date` objects, not strings.
+* `date` is *optional* when only one MVR references a given SVC; the single entry is always the verdict regardless.
+* `date` is *required* on every MVR that references a given SVC as soon as more than one MVR does. A missing `date` in that situation is a semantic validation error.
+* Two MVRs for the same SVC with the *exact same UTC moment* are a validation error — add a time component to disambiguate (e.g. `T09:00:00Z` vs `T14:30:00Z`).
 
 [[report]]
 == Command: report

--- a/src/reqstool/commands/report/report.py
+++ b/src/reqstool/commands/report/report.py
@@ -167,7 +167,7 @@ class ReportCommand:
                 {
                     "id": all_mvrs[mid].id,
                     "passed": all_mvrs[mid].passed,
-                    "date": all_mvrs[mid].date or "",
+                    "date": all_mvrs[mid].date.isoformat() if all_mvrs[mid].date is not None else "",
                     "comment": all_mvrs[mid].comment,
                     "svc_ids": all_mvrs[mid].svc_ids,
                     "superseded": mid in superseded_ids,

--- a/src/reqstool/commands/report/report.py
+++ b/src/reqstool/commands/report/report.py
@@ -14,7 +14,6 @@ from reqstool.common.validator_error_holder import ValidationErrorHolder
 from reqstool.common.validators.semantic_validator import SemanticValidator
 from reqstool.locations.location import LocationInterface
 from reqstool.models.annotations import AnnotationData
-from reqstool.models.mvrs import MVRData
 from reqstool.models.svcs import SVCData
 from reqstool.models.test_data import TEST_RUN_STATUS
 from reqstool.services.statistics_service import StatisticsService
@@ -161,11 +160,21 @@ class ReportCommand:
             # get all implementations for current requirement
             impls: list = self._get_annotation_impls(repo=repo, urn_id=urn_id)
 
-            # Get MVR IDs via SVCs
+            # Get MVR IDs via SVCs, annotated with supersession state
             mvr_ids: list[UrnId] = [mid for svc_uid in svcs_urn_ids for mid in repo.get_mvrs_for_svc(svc_uid)]
-
-            # Get mvrs for current requirement if there are any (else [])
-            mvrs: list[MVRData] = [all_mvrs[mvr_id] for mvr_id in mvr_ids if mvr_id in all_mvrs] if mvr_ids else []
+            superseded_ids = {m.id for svc_uid in svcs_urn_ids for m in repo.get_superseded_mvrs_for_svc(svc_uid)}
+            mvrs = [
+                {
+                    "id": all_mvrs[mid].id,
+                    "passed": all_mvrs[mid].passed,
+                    "date": all_mvrs[mid].date or "",
+                    "comment": all_mvrs[mid].comment,
+                    "svc_ids": all_mvrs[mid].svc_ids,
+                    "superseded": mid in superseded_ids,
+                }
+                for mid in mvr_ids
+                if mid in all_mvrs
+            ]
 
             # generate templates for tests related to current requirement
             automated_test_results_for_req: list = self._get_annotated_automated_test_results_for_req(

--- a/src/reqstool/commands/report/templates/asciidoc/mvrs.j2
+++ b/src/reqstool/commands/report/templates/asciidoc/mvrs.j2
@@ -5,7 +5,11 @@
 [cols="1a,1"]
 |===
 |*MVR ID*|*Result*
-|{{mvr_info.id.urn}}:{{mvr_info.id.id}}| {%if mvr_info.passed%} passed {% else %} failed {%endif%}
+|{{mvr_info.id.urn}}:{{mvr_info.id.id}}{% if mvr_info.superseded %} _(superseded)_{%endif%}| {%if mvr_info.passed%} passed {% else %} failed {%endif%}
+{%if mvr_info.date%}
+2+|*Date*
+2+|{{mvr_info.date}}
+{%endif%}
 2+|*Comment*
 2+|{{mvr_info.comment}}
 2+|*Referenced SVCs*

--- a/src/reqstool/commands/report/templates/markdown/mvrs.j2
+++ b/src/reqstool/commands/report/templates/markdown/mvrs.j2
@@ -5,7 +5,11 @@
 | | |
 |---|---|
 | **MVR ID** | **Result** |
-| {{mvr_info.id.urn}}:{{mvr_info.id.id}} | {%if mvr_info.passed%}passed{% else %}failed{%endif%} |
+| {{mvr_info.id.urn}}:{{mvr_info.id.id}}{% if mvr_info.superseded %} *(superseded)*{%endif%} | {%if mvr_info.passed%}passed{% else %}failed{%endif%} |
+{%if mvr_info.date%}
+| **Date** | |
+| {{mvr_info.date}} | |
+{%endif%}
 | **Comment** | |
 | {{mvr_info.comment}} | |
 | **Referenced SVCs** | |

--- a/src/reqstool/common/queries/details.py
+++ b/src/reqstool/common/queries/details.py
@@ -24,13 +24,11 @@ def _compute_meets(req, repo: RequirementsRepository, svc_urn_ids: list, all_pas
             return False
     else:
         raise ValueError(f"Unhandled IMPLEMENTATION value: {req.implementation}")
-    # Check MVR results — automated test_summary misses manual verification outcomes
-    all_mvrs = repo.get_all_mvrs()
+    # Check MVR results using only the effective (latest) verdict per SVC
     for svc_uid in svc_urn_ids:
-        for mvr_id in repo.get_mvrs_for_svc(svc_uid):
-            mvr = all_mvrs.get(mvr_id)
-            if mvr is not None and not mvr.passed:
-                return False
+        effective = repo.get_effective_mvr_for_svc(svc_uid)
+        if effective is not None and not effective.passed:
+            return False
     return True
 
 
@@ -109,9 +107,10 @@ def get_svc_details(
     if svc is None:
         return None
 
-    mvr_urn_ids = repo.get_mvrs_for_svc(svc.id)
     all_mvrs = repo.get_all_mvrs()
+    mvr_urn_ids = repo.get_mvrs_for_svc(svc.id)
     mvrs = [all_mvrs[uid] for uid in mvr_urn_ids if uid in all_mvrs]
+    superseded_ids = {m.id for m in repo.get_superseded_mvrs_for_svc(svc.id)}
 
     test_annotations = repo.get_annotations_tests_for_svc(svc.id)
     test_results = repo.get_test_results_for_svc(svc.id)
@@ -154,7 +153,9 @@ def get_svc_details(
                 "id": m.id.id,
                 "urn": m.id.urn,
                 "passed": m.passed,
+                "date": m.date or "",
                 "comment": m.comment or "",
+                "superseded": m.id in superseded_ids,
             }
             for m in mvrs
         ],
@@ -181,6 +182,7 @@ def get_mvr_details(
         "id": mvr.id.id,
         "urn": mvr.id.urn,
         "passed": mvr.passed,
+        "date": mvr.date or "",
         "comment": mvr.comment or "",
         "svc_ids": [{"id": s.id, "urn": s.urn} for s in mvr.svc_ids],
         "location": repo.get_urn_location(mvr.id.urn),

--- a/src/reqstool/common/queries/details.py
+++ b/src/reqstool/common/queries/details.py
@@ -153,7 +153,7 @@ def get_svc_details(
                 "id": m.id.id,
                 "urn": m.id.urn,
                 "passed": m.passed,
-                "date": m.date or "",
+                "date": m.date.isoformat() if m.date is not None else "",
                 "comment": m.comment or "",
                 "superseded": m.id in superseded_ids,
             }
@@ -182,7 +182,7 @@ def get_mvr_details(
         "id": mvr.id.id,
         "urn": mvr.id.urn,
         "passed": mvr.passed,
-        "date": mvr.date or "",
+        "date": mvr.date.isoformat() if mvr.date is not None else "",
         "comment": mvr.comment or "",
         "svc_ids": [{"id": s.id, "urn": s.urn} for s in mvr.svc_ids],
         "location": repo.get_urn_location(mvr.id.urn),

--- a/src/reqstool/common/validators/semantic_validator.py
+++ b/src/reqstool/common/validators/semantic_validator.py
@@ -13,6 +13,7 @@ from reqstool.common.models.urn_id import UrnId
 from reqstool.common.utils import Utils
 from reqstool.common.validator_error_holder import ValidationError, ValidationErrorHolder
 from reqstool.models.imports import ImportDataInterface
+from reqstool.models.mvrs import MVRData
 from reqstool.models.raw_datasets import CombinedRawDataset
 from reqstool.models.requirements import RequirementData
 from reqstool.models.svcs import SVCData, SVCsData
@@ -46,6 +47,9 @@ class SemanticValidator:
         )
         self._validation_error_holder.add_errors(
             self._validate_mvr_refers_to_existing_svc_ids(combined_raw_dataset=combined_raw_dataset)
+        )
+        self._validation_error_holder.add_errors(
+            self._validate_mvr_supersession(combined_raw_dataset=combined_raw_dataset)
         )
 
         errors = self._validation_error_holder.get_errors()
@@ -213,6 +217,60 @@ class SemanticValidator:
                             ValidationError(msg=f"MVR refers to non-existing svc id: {self.prettify_urn_id(svc_id)}")
                         )
 
+        return errors
+
+    def _validate_mvr_supersession(self, combined_raw_dataset: CombinedRawDataset) -> List[ValidationError]:
+        """Validate supersession rules when multiple MVRs reference the same SVC.
+
+        Rules:
+        - If >1 MVR references the same SVC, every such MVR must have a ``date`` field.
+        - No two MVRs for the same SVC may represent the exact same UTC moment (tie-break
+          is an error — use a different timestamp to disambiguate).
+        """
+        errors: List[ValidationError] = []
+        for model, model_data in combined_raw_dataset.raw_datasets.items():
+            if model != combined_raw_dataset.initial_model_urn or not model_data.mvrs_data:
+                continue
+
+            svc_to_mvrs: dict[UrnId, List[MVRData]] = {}
+            for mvr_data in model_data.mvrs_data.results.values():
+                for svc_id in mvr_data.svc_ids:
+                    svc_to_mvrs.setdefault(svc_id, []).append(mvr_data)
+
+            for svc_id, mvrs in svc_to_mvrs.items():
+                if len(mvrs) > 1:
+                    errors.extend(self._check_mvr_dates_for_svc(svc_id, mvrs))
+
+        return errors
+
+    def _check_mvr_dates_for_svc(self, svc_id: UrnId, mvrs: List[MVRData]) -> List[ValidationError]:
+        errors: List[ValidationError] = []
+        dated: list[tuple] = []
+        for mvr in mvrs:
+            if mvr.date is None:
+                errors.append(
+                    ValidationError(
+                        msg=f"MVR '{self.prettify_urn_id(mvr.id)}' references SVC "
+                        f"'{self.prettify_urn_id(svc_id)}' but has no 'date' field. "
+                        f"A 'date' is required when multiple MVRs reference the same SVC."
+                    )
+                )
+            else:
+                dated.append((mvr.date, mvr))
+
+        seen: dict = {}
+        for ts, mvr in dated:
+            if ts in seen:
+                errors.append(
+                    ValidationError(
+                        msg=f"MVRs '{self.prettify_urn_id(seen[ts].id)}' and "
+                        f"'{self.prettify_urn_id(mvr.id)}' both reference SVC "
+                        f"'{self.prettify_urn_id(svc_id)}' at the same UTC moment. "
+                        f"Use a different timestamp to disambiguate."
+                    )
+                )
+            else:
+                seen[ts] = mvr
         return errors
 
     def _validate_svc_imports_filter_has_excludes_xor_includes(self, svc_data: SVCsData) -> List[ValidationError]:

--- a/src/reqstool/model_generators/mvrs_model_generator.py
+++ b/src/reqstool/model_generators/mvrs_model_generator.py
@@ -75,6 +75,7 @@ class MVRsModelGenerator:
                 svc_ids=Utils.convert_ids_to_urn_id(ids=result.svc_ids, urn=self.urn),
                 comment=result.comment,
                 passed=result.pass_,
+                date=result.date,
                 source_line=source_lines[result.id][0] if result.id in source_lines else None,
                 source_col_start=source_lines[result.id][1] if result.id in source_lines else None,
                 source_col_end=source_lines[result.id][2] if result.id in source_lines else None,

--- a/src/reqstool/models/generated/manual_verification_results_schema.py
+++ b/src/reqstool/models/generated/manual_verification_results_schema.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
 
 
 class Results(BaseModel):
@@ -27,6 +27,10 @@ class Results(BaseModel):
     pass_: Annotated[bool, Field(alias='pass')]
     """
     Boolean if test passed
+    """
+    date: AwareDatetime | None = None
+    """
+    Timezone-aware ISO 8601 date-time when the verification was performed (e.g. "2026-01-15T14:30:00Z" or "2026-01-15T14:30:00+01:00"). Required when more than one MVR references the same SVC.
     """
 
 

--- a/src/reqstool/models/generated/manual_verification_results_schema.py
+++ b/src/reqstool/models/generated/manual_verification_results_schema.py
@@ -30,7 +30,7 @@ class Results(BaseModel):
     """
     date: AwareDatetime | None = None
     """
-    Timezone-aware ISO 8601 date-time when the verification was performed (e.g. "2026-01-15T14:30:00Z" or "2026-01-15T14:30:00+01:00"). Required when more than one MVR references the same SVC.
+    RFC 3339 date-time when the verification was performed (e.g. "2026-01-15T14:30:00Z" or "2026-01-15T14:30:00+01:00"). A timezone offset is required. Required when more than one MVR references the same SVC.
     """
 
 

--- a/src/reqstool/models/mvrs.py
+++ b/src/reqstool/models/mvrs.py
@@ -1,5 +1,6 @@
 # Copyright © LFV
 
+from datetime import datetime
 from typing import Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -13,6 +14,7 @@ class MVRData(BaseModel):
     id: UrnId
     comment: Optional[str] = None
     passed: bool
+    date: Optional[datetime] = None
     svc_ids: List[UrnId] = Field(default_factory=list)
     source_line: Optional[int] = None
     source_col_start: Optional[int] = None

--- a/src/reqstool/resources/schemas/v1/export_output.schema.json
+++ b/src/reqstool/resources/schemas/v1/export_output.schema.json
@@ -281,7 +281,7 @@
                 },
                 "date": {
                     "type": "string",
-                    "description": "ISO 8601 date or date-time when the verification was performed"
+                    "description": "RFC 3339 date-time when the verification was performed"
                 },
                 "comment": {
                     "type": ["string", "null"],

--- a/src/reqstool/resources/schemas/v1/export_output.schema.json
+++ b/src/reqstool/resources/schemas/v1/export_output.schema.json
@@ -279,6 +279,10 @@
                     "type": "boolean",
                     "description": "Whether the manual verification passed"
                 },
+                "date": {
+                    "type": "string",
+                    "description": "ISO 8601 date or date-time when the verification was performed"
+                },
                 "comment": {
                     "type": ["string", "null"],
                     "description": "Optional comment about the verification result"

--- a/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
+++ b/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
@@ -39,6 +39,11 @@
                 "pass": {
                     "type": "boolean",
                     "description": "Boolean if test passed"
+                },
+                "date": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Timezone-aware ISO 8601 date-time when the verification was performed (e.g. \"2026-01-15T14:30:00Z\" or \"2026-01-15T14:30:00+01:00\"). Required when more than one MVR references the same SVC."
                 }
             },
             "required": [

--- a/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
+++ b/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
@@ -43,7 +43,7 @@
                 "date": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Timezone-aware ISO 8601 date-time when the verification was performed (e.g. \"2026-01-15T14:30:00Z\" or \"2026-01-15T14:30:00+01:00\"). Required when more than one MVR references the same SVC."
+                    "description": "RFC 3339 date-time when the verification was performed (e.g. \"2026-01-15T14:30:00Z\" or \"2026-01-15T14:30:00+01:00\"). A timezone offset is required. Required when more than one MVR references the same SVC."
                 }
             },
             "required": [

--- a/src/reqstool/services/export_service.py
+++ b/src/reqstool/services/export_service.py
@@ -170,6 +170,8 @@ class ExportService:
                 "passed": mvr.passed,
                 "svc_ids": [str(sid) for sid in mvr.svc_ids],
             }
+            if mvr.date is not None:
+                mvr_dict["date"] = mvr.date
             if mvr.comment is not None:
                 mvr_dict["comment"] = mvr.comment
             mvrs[str(uid)] = mvr_dict

--- a/src/reqstool/services/export_service.py
+++ b/src/reqstool/services/export_service.py
@@ -171,7 +171,7 @@ class ExportService:
                 "svc_ids": [str(sid) for sid in mvr.svc_ids],
             }
             if mvr.date is not None:
-                mvr_dict["date"] = mvr.date
+                mvr_dict["date"] = mvr.date.isoformat()
             if mvr.comment is not None:
                 mvr_dict["comment"] = mvr.comment
             mvrs[str(uid)] = mvr_dict

--- a/src/reqstool/services/statistics_service.py
+++ b/src/reqstool/services/statistics_service.py
@@ -129,20 +129,14 @@ class StatisticsService:
         self._totals.total_svcs = len(all_svcs)
         self._totals.total_annotated_tests = len(automated_test_results)
 
-        # Count only effective MVRs — superseded ones are audit history, not active verdicts
-        effective_mvr_count = 0
-        for svc_uid in all_svcs:
-            effective = self._repo.get_effective_mvr_for_svc(svc_uid)
-            if effective is not None:
-                effective_mvr_count += 1
-                if effective.passed:
-                    self._totals.passed_tests += 1
-                    self._totals.passed_manual_tests += 1
-                else:
-                    self._totals.failed_tests += 1
-                    self._totals.failed_manual_tests += 1
-        self._totals.total_manual_tests = effective_mvr_count
-        self._totals.total_tests = self._totals.total_annotated_tests + effective_mvr_count
+        # Single aggregation query: one effective verdict per SVC, superseded excluded
+        eff_total, eff_passed, eff_failed = self._repo.get_effective_mvr_verdict_counts()
+        self._totals.total_manual_tests = eff_total
+        self._totals.passed_manual_tests = eff_passed
+        self._totals.failed_manual_tests = eff_failed
+        self._totals.passed_tests += eff_passed
+        self._totals.failed_tests += eff_failed
+        self._totals.total_tests = self._totals.total_annotated_tests + eff_total
 
         self._count_automated_test_totals(annotations_tests, automated_test_results)
 

--- a/src/reqstool/services/statistics_service.py
+++ b/src/reqstool/services/statistics_service.py
@@ -114,31 +114,35 @@ class StatisticsService:
     def _calculate(self):
         requirements = self._repo.get_all_requirements()
         all_svcs = self._repo.get_all_svcs()
-        all_mvrs = self._repo.get_all_mvrs()
         annotations_impls = self._repo.get_annotations_impls()
         annotations_tests = self._repo.get_annotations_tests()
         automated_test_results = self._repo.get_automated_test_results()
 
-        self._calculate_global_totals(all_svcs, all_mvrs, annotations_tests, automated_test_results)
+        self._calculate_global_totals(all_svcs, annotations_tests, automated_test_results)
 
         for urn_id, req_data in requirements.items():
             self._calculate_requirement_stats(
-                urn_id, req_data, all_svcs, all_mvrs, annotations_impls, annotations_tests, automated_test_results
+                urn_id, req_data, all_svcs, annotations_impls, annotations_tests, automated_test_results
             )
 
-    def _calculate_global_totals(self, all_svcs, all_mvrs, annotations_tests, automated_test_results):
+    def _calculate_global_totals(self, all_svcs, annotations_tests, automated_test_results):
         self._totals.total_svcs = len(all_svcs)
-        self._totals.total_manual_tests = len(all_mvrs)
         self._totals.total_annotated_tests = len(automated_test_results)
-        self._totals.total_tests = self._totals.total_annotated_tests + self._totals.total_manual_tests
 
-        for mvr_data in all_mvrs.values():
-            if mvr_data.passed:
-                self._totals.passed_tests += 1
-                self._totals.passed_manual_tests += 1
-            else:
-                self._totals.failed_tests += 1
-                self._totals.failed_manual_tests += 1
+        # Count only effective MVRs — superseded ones are audit history, not active verdicts
+        effective_mvr_count = 0
+        for svc_uid in all_svcs:
+            effective = self._repo.get_effective_mvr_for_svc(svc_uid)
+            if effective is not None:
+                effective_mvr_count += 1
+                if effective.passed:
+                    self._totals.passed_tests += 1
+                    self._totals.passed_manual_tests += 1
+                else:
+                    self._totals.failed_tests += 1
+                    self._totals.failed_manual_tests += 1
+        self._totals.total_manual_tests = effective_mvr_count
+        self._totals.total_tests = self._totals.total_annotated_tests + effective_mvr_count
 
         self._count_automated_test_totals(annotations_tests, automated_test_results)
 
@@ -164,7 +168,7 @@ class StatisticsService:
                                     self._totals.total_tests -= 1
 
     def _calculate_requirement_stats(
-        self, urn_id, req_data, all_svcs, all_mvrs, annotations_impls, annotations_tests, automated_test_results
+        self, urn_id, req_data, all_svcs, annotations_impls, annotations_tests, automated_test_results
     ):
         svcs_urn_ids = self._repo.get_svcs_for_req(urn_id)
         svcs = [all_svcs[sid] for sid in svcs_urn_ids if sid in all_svcs]
@@ -174,7 +178,7 @@ class StatisticsService:
 
         nr_of_implementations = len(annotations_impls.get(urn_id, []))
 
-        mvr_stats = self._get_requirement_mvr_stats(svcs_urn_ids, all_mvrs, svcs, should_have_mvrs)
+        mvr_stats = self._get_requirement_mvr_stats(svcs_urn_ids, svcs, should_have_mvrs)
         automated_test_stats = self._get_requirement_automated_stats(
             svcs_urn_ids, all_svcs, annotations_tests, automated_test_results, svcs, should_have_automated_tests
         )
@@ -200,12 +204,30 @@ class StatisticsService:
 
         self._update_requirement_totals(req_data, nr_of_implementations, completed, automated_test_stats, mvr_stats)
 
-    def _get_requirement_mvr_stats(self, svcs_urn_ids, all_mvrs, svcs, should_have_mvrs):
+    def _get_requirement_mvr_stats(self, svcs_urn_ids, svcs, should_have_mvrs) -> TestStats:
         if not should_have_mvrs:
             return TestStats(not_applicable=True)
-        mvr_ids = [mid for svc_uid in svcs_urn_ids for mid in self._repo.get_mvrs_for_svc(svc_uid)]
-        mvrs = [all_mvrs[mid] for mid in mvr_ids if mid in all_mvrs]
-        return self._get_mvr_stats(mvrs=mvrs if mvrs else None, svcs=svcs)
+
+        total = 0
+        passed = 0
+        failed = 0
+        missing = 0
+        svc_map = {s.id: s for s in svcs}
+        for svc_uid in svcs_urn_ids:
+            svc = svc_map.get(svc_uid)
+            if svc is None or svc.verification not in EXPECTS_MVRS:
+                continue
+            effective = self._repo.get_effective_mvr_for_svc(svc_uid)
+            if effective is None:
+                missing += 1
+            elif effective.passed:
+                total += 1
+                passed += 1
+            else:
+                total += 1
+                failed += 1
+
+        return TestStats(total=total, passed=passed, failed=failed, missing=missing)
 
     def _get_requirement_automated_stats(
         self, svcs_urn_ids, all_svcs, annotations_tests, automated_test_results, svcs, should_have_automated_tests
@@ -290,16 +312,6 @@ class StatisticsService:
                     missing += 1
 
         return TestStats(total=total, passed=passed, failed=failed, skipped=skipped, missing=missing)
-
-    def _get_mvr_stats(self, mvrs, svcs) -> TestStats:
-        if not mvrs:
-            no_of_expected = sum(1 for svc in svcs if svc.verification in EXPECTS_MVRS)
-            return TestStats(missing=no_of_expected)
-
-        total = len(mvrs)
-        passed = sum(1 for mvr in mvrs if mvr.passed)
-        failed = total - passed
-        return TestStats(total=total, passed=passed, failed=failed)
 
     def _get_annotated_automated_test_results_for_req(
         self,

--- a/src/reqstool/storage/database.py
+++ b/src/reqstool/storage/database.py
@@ -114,13 +114,14 @@ class RequirementsDatabase:
 
     def insert_mvr(self, urn: str, mvr: MVRData) -> None:
         self._conn.execute(
-            "INSERT INTO mvrs (urn, id, passed, comment, source_line, source_col_start, source_col_end)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO mvrs (urn, id, passed, comment, date, source_line, source_col_start, source_col_end)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 urn,
                 mvr.id.id,
                 int(mvr.passed),
                 mvr.comment,
+                mvr.date.isoformat() if mvr.date is not None else None,
                 mvr.source_line,
                 mvr.source_col_start,
                 mvr.source_col_end,

--- a/src/reqstool/storage/requirements_repository.py
+++ b/src/reqstool/storage/requirements_repository.py
@@ -1,6 +1,8 @@
 # Copyright © LFV
 
 
+from datetime import datetime
+
 from packaging.version import Version
 
 from reqstool.common.models.lifecycle import LIFECYCLESTATE, LifecycleData
@@ -139,6 +141,47 @@ class RequirementsRepository:
             (svc_urn_id.urn, svc_urn_id.id),
         ).fetchall()
         return [UrnId(urn=row["mvr_urn"], id=row["mvr_id"]) for row in rows]
+
+    def get_effective_mvr_for_svc(self, svc_urn_id: UrnId) -> MVRData | None:
+        """Return the MVR that represents the current verdict for a SVC.
+
+        When a SVC has multiple MVRs the one with the latest date (UTC-normalized
+        via SQLite's datetime() function) is the verdict; all others are audit
+        history.  When there is only one MVR (dated or not) it is returned
+        directly.  Returns None when no MVRs exist for the SVC.
+        """
+        row = self._db.connection.execute(
+            """
+            SELECT m.*
+            FROM mvrs m
+            JOIN mvr_svc_links l ON m.urn = l.mvr_urn AND m.id = l.mvr_id
+            WHERE l.svc_urn = ? AND l.svc_id = ?
+            ORDER BY datetime(m.date) DESC NULLS LAST
+            LIMIT 1
+            """,
+            (svc_urn_id.urn, svc_urn_id.id),
+        ).fetchone()
+        return self._row_to_mvr_data(row) if row else None
+
+    def get_superseded_mvrs_for_svc(self, svc_urn_id: UrnId) -> list[MVRData]:
+        """Return all MVRs for a SVC that are NOT the effective (latest) one.
+
+        These are retained as audit history but excluded from the verdict.
+        """
+        effective = self.get_effective_mvr_for_svc(svc_urn_id)
+        if effective is None:
+            return []
+        rows = self._db.connection.execute(
+            """
+            SELECT m.*
+            FROM mvrs m
+            JOIN mvr_svc_links l ON m.urn = l.mvr_urn AND m.id = l.mvr_id
+            WHERE l.svc_urn = ? AND l.svc_id = ?
+              AND NOT (m.urn = ? AND m.id = ?)
+            """,
+            (svc_urn_id.urn, svc_urn_id.id, effective.id.urn, effective.id.id),
+        ).fetchall()
+        return [self._row_to_mvr_data(row) for row in rows]
 
     def get_annotations_impls(self, urn: str | None = None) -> dict[UrnId, list[AnnotationData]]:
         sql = "SELECT req_urn, req_id, element_kind, fqn FROM annotations_impls" + (" WHERE req_urn = ?" if urn else "")
@@ -345,10 +388,12 @@ class RequirementsRepository:
         ).fetchall()
         svc_ids = [UrnId(urn=r["svc_urn"], id=r["svc_id"]) for r in svc_link_rows]
 
+        raw_date = row["date"]
         return MVRData(
             id=UrnId(urn=urn, id=mvr_id),
             comment=row["comment"],
             passed=bool(row["passed"]),
+            date=datetime.fromisoformat(raw_date) if raw_date is not None else None,
             svc_ids=svc_ids,
             source_line=row["source_line"],
             source_col_start=row["source_col_start"],

--- a/src/reqstool/storage/requirements_repository.py
+++ b/src/reqstool/storage/requirements_repository.py
@@ -149,15 +149,23 @@ class RequirementsRepository:
         via SQLite's datetime() function) is the verdict; all others are audit
         history.  When there is only one MVR (dated or not) it is returned
         directly.  Returns None when no MVRs exist for the SVC.
+
+        datetime(m.date) normalises TZ offsets to UTC so mixed-offset strings
+        (e.g. +01:00 vs Z) sort correctly.  NULLS LAST places undated MVRs after
+        all dated ones so a single undated MVR is still returned as the verdict.
         """
         row = self._db.connection.execute(
             """
             SELECT m.*
-            FROM mvrs m
-            JOIN mvr_svc_links l ON m.urn = l.mvr_urn AND m.id = l.mvr_id
-            WHERE l.svc_urn = ? AND l.svc_id = ?
-            ORDER BY datetime(m.date) DESC NULLS LAST
-            LIMIT 1
+            FROM (
+                SELECT m.*, ROW_NUMBER() OVER (
+                    PARTITION BY l.svc_urn, l.svc_id
+                    ORDER BY datetime(m.date) DESC NULLS LAST
+                ) AS rn
+                FROM mvrs m
+                JOIN mvr_svc_links l ON m.urn = l.mvr_urn AND m.id = l.mvr_id
+                WHERE l.svc_urn = ? AND l.svc_id = ?
+            ) m WHERE rn = 1
             """,
             (svc_urn_id.urn, svc_urn_id.id),
         ).fetchone()
@@ -167,21 +175,51 @@ class RequirementsRepository:
         """Return all MVRs for a SVC that are NOT the effective (latest) one.
 
         These are retained as audit history but excluded from the verdict.
+        Uses the same ROW_NUMBER ranking as get_effective_mvr_for_svc so the
+        two methods are always consistent without requiring an extra round-trip.
         """
-        effective = self.get_effective_mvr_for_svc(svc_urn_id)
-        if effective is None:
-            return []
         rows = self._db.connection.execute(
             """
             SELECT m.*
-            FROM mvrs m
-            JOIN mvr_svc_links l ON m.urn = l.mvr_urn AND m.id = l.mvr_id
-            WHERE l.svc_urn = ? AND l.svc_id = ?
-              AND NOT (m.urn = ? AND m.id = ?)
+            FROM (
+                SELECT m.*, ROW_NUMBER() OVER (
+                    PARTITION BY l.svc_urn, l.svc_id
+                    ORDER BY datetime(m.date) DESC NULLS LAST
+                ) AS rn
+                FROM mvrs m
+                JOIN mvr_svc_links l ON m.urn = l.mvr_urn AND m.id = l.mvr_id
+                WHERE l.svc_urn = ? AND l.svc_id = ?
+            ) m WHERE rn > 1
             """,
-            (svc_urn_id.urn, svc_urn_id.id, effective.id.urn, effective.id.id),
+            (svc_urn_id.urn, svc_urn_id.id),
         ).fetchall()
         return [self._row_to_mvr_data(row) for row in rows]
+
+    def get_effective_mvr_verdict_counts(self) -> tuple[int, int, int]:
+        """Return (total, passed, failed) counts of effective-MVR verdicts across all SVCs.
+
+        Uses a single aggregation query — one effective MVR per SVC, with the
+        same datetime() ranking used by get_effective_mvr_for_svc.
+        """
+        row = self._db.connection.execute(
+            """
+            SELECT
+                COUNT(*) AS total,
+                SUM(passed) AS passed,
+                SUM(1 - passed) AS failed
+            FROM (
+                SELECT m.passed, ROW_NUMBER() OVER (
+                    PARTITION BY l.svc_urn, l.svc_id
+                    ORDER BY datetime(m.date) DESC NULLS LAST
+                ) AS rn
+                FROM mvrs m
+                JOIN mvr_svc_links l ON m.urn = l.mvr_urn AND m.id = l.mvr_id
+            ) WHERE rn = 1
+            """
+        ).fetchone()
+        if row is None:
+            return (0, 0, 0)
+        return (row["total"] or 0, row["passed"] or 0, row["failed"] or 0)
 
     def get_annotations_impls(self, urn: str | None = None) -> dict[UrnId, list[AnnotationData]]:
         sql = "SELECT req_urn, req_id, element_kind, fqn FROM annotations_impls" + (" WHERE req_urn = ?" if urn else "")

--- a/src/reqstool/storage/schema.py
+++ b/src/reqstool/storage/schema.py
@@ -150,6 +150,7 @@ CREATE INDEX IF NOT EXISTS idx_svc_req_links_svc ON svc_requirement_links (svc_u
 CREATE INDEX IF NOT EXISTS idx_svc_req_links_req ON svc_requirement_links (req_urn, req_id);
 CREATE INDEX IF NOT EXISTS idx_mvr_svc_links_mvr ON mvr_svc_links (mvr_urn, mvr_id);
 CREATE INDEX IF NOT EXISTS idx_mvr_svc_links_svc ON mvr_svc_links (svc_urn, svc_id);
+CREATE INDEX IF NOT EXISTS idx_mvrs_date ON mvrs(date);
 CREATE INDEX IF NOT EXISTS idx_annotations_impls_fk ON annotations_impls (req_urn, req_id);
 CREATE INDEX IF NOT EXISTS idx_annotations_tests_fk ON annotations_tests (svc_urn, svc_id);
 CREATE INDEX IF NOT EXISTS idx_parsing_graph_parent ON parsing_graph (parent_urn);

--- a/src/reqstool/storage/schema.py
+++ b/src/reqstool/storage/schema.py
@@ -75,6 +75,7 @@ CREATE TABLE IF NOT EXISTS mvrs (
     id TEXT NOT NULL,
     passed INTEGER NOT NULL,
     comment TEXT,
+    date TEXT,
     source_line INTEGER,
     source_col_start INTEGER,
     source_col_end INTEGER,

--- a/tests/unit/reqstool/common/queries/test_details.py
+++ b/tests/unit/reqstool/common/queries/test_details.py
@@ -413,3 +413,128 @@ def test_meets_requirements_in_code_failing_mvr_is_false():
     assert result is not None
     assert result["meets_requirements"] is False, "failing MVR should make IN_CODE meets_requirements False"
     db.close()
+
+
+# ---------------------------------------------------------------------------
+# Supersession in details queries
+# ---------------------------------------------------------------------------
+
+
+def _make_db_with_superseded_mvrs(mvr_pass_sequence: list[tuple[str, bool]]) -> tuple:
+    """Build a minimal DB with multiple dated MVRs for the same SVC.
+
+    mvr_pass_sequence: list of (iso_datetime_str, passed) in order.
+    Returns (db, req_id, svc_id).
+    """
+    from datetime import datetime
+
+    from reqstool.models.mvrs import MVRData
+
+    db = RequirementsDatabase()
+    db.set_metadata("initial_urn", "ms-001")
+    req_id = UrnId(urn="ms-001", id="REQ_SUPER")
+    svc_id = UrnId(urn="ms-001", id="SVC_SUPER")
+    req = RequirementData(
+        id=req_id,
+        title="T",
+        significance=SIGNIFICANCETYPES.SHALL,
+        description="D",
+        implementation=IMPLEMENTATION.NOT_APPLICABLE,
+        categories=[CATEGORIES.FUNCTIONAL_SUITABILITY],
+        revision="1.0.0",
+    )
+    svc = SVCData(
+        id=svc_id,
+        title="S",
+        verification=VERIFICATIONTYPES.MANUAL_TEST,
+        revision="1.0.0",
+        requirement_ids=[req_id],
+    )
+    db.insert_requirement(req_id.urn, req)
+    db.insert_svc(svc_id.urn, svc)
+    for i, (dt_str, passed) in enumerate(mvr_pass_sequence):
+        mvr_id = UrnId(urn="ms-001", id=f"MVR_{i:03d}")
+        mvr = MVRData(
+            id=mvr_id,
+            passed=passed,
+            svc_ids=[svc_id],
+            date=datetime.fromisoformat(dt_str),
+        )
+        db.insert_mvr(mvr_id.urn, mvr)
+    db.commit()
+    return db, req_id, svc_id
+
+
+def test_compute_meets_superseded_fail_latest_pass_is_true():
+    """fail→pass: latest (passing) MVR makes _compute_meets True."""
+    db, req_id, _ = _make_db_with_superseded_mvrs([("2026-01-01T00:00:00Z", False), ("2026-01-02T00:00:00Z", True)])
+    repo = RequirementsRepository(db)
+    result = get_requirement_status(req_id.id, repo)
+    assert result is not None
+    assert result["meets_requirements"] is True
+    db.close()
+
+
+def test_compute_meets_superseded_pass_latest_fail_is_false():
+    """pass→fail: latest (failing) MVR makes _compute_meets False."""
+    db, req_id, _ = _make_db_with_superseded_mvrs([("2026-01-01T00:00:00Z", True), ("2026-01-02T00:00:00Z", False)])
+    repo = RequirementsRepository(db)
+    result = get_requirement_status(req_id.id, repo)
+    assert result is not None
+    assert result["meets_requirements"] is False
+    db.close()
+
+
+def test_get_svc_details_superseded_flag():
+    """get_svc_details marks older MVRs as superseded=True, latest as superseded=False."""
+    db, _, svc_id = _make_db_with_superseded_mvrs([("2026-01-01T00:00:00Z", False), ("2026-01-02T00:00:00Z", True)])
+    db.set_metadata("initial_urn", "ms-001")
+    repo = RequirementsRepository(db)
+    result = get_svc_details(svc_id.id, repo)
+    assert result is not None
+    mvrs = result["mvrs"]
+    assert len(mvrs) == 2
+    superseded = [m for m in mvrs if m["superseded"]]
+    effective = [m for m in mvrs if not m["superseded"]]
+    assert len(superseded) == 1
+    assert len(effective) == 1
+    assert effective[0]["passed"] is True
+    assert effective[0]["date"] == "2026-01-02T00:00:00+00:00"
+    db.close()
+
+
+def test_get_mvr_details_includes_date():
+    """get_mvr_details returns the date field as an ISO string."""
+    from datetime import datetime
+
+    from reqstool.models.mvrs import MVRData
+
+    db = RequirementsDatabase()
+    db.set_metadata("initial_urn", "ms-001")
+    req_id = UrnId(urn="ms-001", id="REQ_D")
+    svc_id = UrnId(urn="ms-001", id="SVC_D")
+    mvr_id = UrnId(urn="ms-001", id="MVR_D")
+    req = RequirementData(
+        id=req_id,
+        title="T",
+        significance=SIGNIFICANCETYPES.SHALL,
+        description="D",
+        implementation=IMPLEMENTATION.NOT_APPLICABLE,
+        categories=[CATEGORIES.FUNCTIONAL_SUITABILITY],
+        revision="1.0.0",
+    )
+    svc = SVCData(
+        id=svc_id, title="S", verification=VERIFICATIONTYPES.MANUAL_TEST, revision="1.0.0", requirement_ids=[req_id]
+    )
+    dt = datetime.fromisoformat("2026-03-15T09:00:00+01:00")
+    mvr = MVRData(id=mvr_id, passed=True, svc_ids=[svc_id], date=dt)
+    db.insert_requirement(req_id.urn, req)
+    db.insert_svc(svc_id.urn, svc)
+    db.insert_mvr(mvr_id.urn, mvr)
+    db.commit()
+
+    repo = RequirementsRepository(db)
+    result = get_mvr_details(mvr_id.id, repo)
+    assert result is not None
+    assert result["date"] == dt.isoformat()
+    db.close()

--- a/tests/unit/reqstool/common/validators/test_semantic_validator.py
+++ b/tests/unit/reqstool/common/validators/test_semantic_validator.py
@@ -389,3 +389,117 @@ def test_log_all_errors_includes_error_message(caplog):
     with caplog.at_level(logging.INFO):
         sv._log_all_errors()
     assert "something went wrong" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# _validate_mvr_supersession / _check_mvr_dates_for_svc
+# ---------------------------------------------------------------------------
+
+
+def _mvr_supersession_dataset(mvrs: list):
+    """Build a minimal CombinedRawDataset with the given MVRData list."""
+    from reqstool.models.mvrs import MVRsData
+    from reqstool.models.raw_datasets import CombinedRawDataset, RawDataset
+
+    urn = "ms-001"
+    mvrs_data = MVRsData(results={m.id: m for m in mvrs})
+    rd = RawDataset(mvrs_data=mvrs_data)
+    return CombinedRawDataset(
+        initial_model_urn=urn,
+        raw_datasets={urn: rd},
+    )
+
+
+def test_mvr_supersession_single_undated_no_error():
+    """Single MVR with no date is allowed — supersession rules only apply when >1 MVR per SVC."""
+    from reqstool.common.models.urn_id import UrnId
+    from reqstool.models.mvrs import MVRData
+
+    mvr = MVRData(
+        id=UrnId(urn="ms-001", id="MVR_001"),
+        svc_ids=[UrnId(urn="ms-001", id="SVC_001")],
+        passed=True,
+    )
+    dataset = _mvr_supersession_dataset([mvr])
+    holder = ValidationErrorHolder()
+    errors = SemanticValidator(holder)._validate_mvr_supersession(dataset)
+    assert errors == []
+
+
+def test_mvr_supersession_two_dated_different_timestamps_no_error():
+    """Two MVRs for the same SVC with distinct timestamps — valid."""
+    from datetime import datetime
+
+    from reqstool.common.models.urn_id import UrnId
+    from reqstool.models.mvrs import MVRData
+
+    svc = UrnId(urn="ms-001", id="SVC_001")
+    mvr_a = MVRData(
+        id=UrnId(urn="ms-001", id="MVR_A"),
+        svc_ids=[svc],
+        passed=False,
+        date=datetime.fromisoformat("2026-01-01T00:00:00+00:00"),
+    )
+    mvr_b = MVRData(
+        id=UrnId(urn="ms-001", id="MVR_B"),
+        svc_ids=[svc],
+        passed=True,
+        date=datetime.fromisoformat("2026-01-02T00:00:00+00:00"),
+    )
+    dataset = _mvr_supersession_dataset([mvr_a, mvr_b])
+    holder = ValidationErrorHolder()
+    errors = SemanticValidator(holder)._validate_mvr_supersession(dataset)
+    assert errors == []
+
+
+def test_mvr_supersession_missing_date_raises_error():
+    """Two MVRs for the same SVC where one lacks a date — must error."""
+    from reqstool.common.models.urn_id import UrnId
+    from reqstool.models.mvrs import MVRData
+
+    svc = UrnId(urn="ms-001", id="SVC_001")
+    mvr_a = MVRData(
+        id=UrnId(urn="ms-001", id="MVR_A"),
+        svc_ids=[svc],
+        passed=False,
+        date=None,
+    )
+    mvr_b = MVRData(
+        id=UrnId(urn="ms-001", id="MVR_B"),
+        svc_ids=[svc],
+        passed=True,
+        date=None,
+    )
+    dataset = _mvr_supersession_dataset([mvr_a, mvr_b])
+    holder = ValidationErrorHolder()
+    errors = SemanticValidator(holder)._validate_mvr_supersession(dataset)
+    assert len(errors) >= 1
+    assert any("date" in e.msg for e in errors)
+
+
+def test_mvr_supersession_tie_same_utc_moment_raises_error():
+    """Two MVRs for the same SVC with identical UTC moment (different offsets) — must error."""
+    from datetime import datetime, timedelta, timezone
+
+    from reqstool.common.models.urn_id import UrnId
+    from reqstool.models.mvrs import MVRData
+
+    svc = UrnId(urn="ms-001", id="SVC_001")
+    # 14:30 +01:00 == 13:30 Z — same UTC instant
+    mvr_a = MVRData(
+        id=UrnId(urn="ms-001", id="MVR_A"),
+        svc_ids=[svc],
+        passed=False,
+        date=datetime(2026, 1, 15, 14, 30, 0, tzinfo=timezone(timedelta(hours=1))),
+    )
+    mvr_b = MVRData(
+        id=UrnId(urn="ms-001", id="MVR_B"),
+        svc_ids=[svc],
+        passed=True,
+        date=datetime(2026, 1, 15, 13, 30, 0, tzinfo=timezone.utc),
+    )
+    dataset = _mvr_supersession_dataset([mvr_a, mvr_b])
+    holder = ValidationErrorHolder()
+    errors = SemanticValidator(holder)._validate_mvr_supersession(dataset)
+    assert len(errors) == 1
+    assert "same UTC moment" in errors[0].msg

--- a/tests/unit/reqstool/services/test_export_service.py
+++ b/tests/unit/reqstool/services/test_export_service.py
@@ -207,3 +207,44 @@ def test_export_empty_database():
     assert result["svcs"] == {}
     assert result["mvrs"] == {}
     db.close()
+
+
+# -- MVR date serialization --
+
+
+def test_export_mvr_with_date_serializes_as_iso_string(populated_db):
+    """MVR date field must be an ISO 8601 string in the export dict (not a datetime object)."""
+    import json
+    from datetime import datetime
+
+    dated_mvr_id = UrnId(urn=URN, id="MVR_DATED")
+    dt = datetime.fromisoformat("2026-03-15T14:30:00+01:00")
+    dated_mvr = MVRData(id=dated_mvr_id, passed=True, svc_ids=[SVC_ID_2], date=dt)
+    populated_db.insert_mvr(dated_mvr_id.urn, dated_mvr)
+    populated_db.commit()
+
+    repo = RequirementsRepository(populated_db)
+    result = ExportService(repo).to_export_dict()
+
+    mvr_entry = result["mvrs"].get(str(dated_mvr_id))
+    assert mvr_entry is not None
+    assert "date" in mvr_entry
+    assert isinstance(mvr_entry["date"], str), "date must be a string for JSON serialization"
+    assert mvr_entry["date"] == dt.isoformat()
+    # Must be JSON-serializable without a custom encoder
+    json.dumps(result)  # raises TypeError if datetime slipped through
+
+
+def test_export_mvr_without_date_omits_field(populated_db):
+    """MVR with no date must not include a 'date' key in the export dict."""
+    undated_mvr_id = UrnId(urn=URN, id="MVR_UNDATED")
+    undated_mvr = MVRData(id=undated_mvr_id, passed=True, svc_ids=[SVC_ID_2], date=None)
+    populated_db.insert_mvr(undated_mvr_id.urn, undated_mvr)
+    populated_db.commit()
+
+    repo = RequirementsRepository(populated_db)
+    result = ExportService(repo).to_export_dict()
+
+    mvr_entry = result["mvrs"].get(str(undated_mvr_id))
+    assert mvr_entry is not None
+    assert "date" not in mvr_entry

--- a/tests/unit/reqstool/services/test_statistics_service.py
+++ b/tests/unit/reqstool/services/test_statistics_service.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 
 from reqstool.common.models.urn_id import UrnId
@@ -270,6 +272,76 @@ def test_total_svcs(db):
     repo = RequirementsRepository(db)
     stats = StatisticsService(repo)
     assert stats.total_statistics.total_svcs == 2
+
+
+# -- MVR supersession --
+
+
+MVR_ID_A = UrnId(urn=URN, id="MVR_A")
+MVR_ID_B = UrnId(urn=URN, id="MVR_B")
+
+
+def _insert_mvr_dated(db, mvr_id, svc_ids, passed, date_iso: str | None):
+    date = datetime.fromisoformat(date_iso) if date_iso else None
+    mvr = MVRData(id=mvr_id, passed=passed, svc_ids=svc_ids, date=date)
+    db.insert_mvr(mvr_id.urn, mvr)
+
+
+def test_supersession_fail_then_pass_counts_as_passed(db):
+    """The core bug from issue #72: fail→pass should yield T1 P1, not T2 P1 F1."""
+    _insert_req(db)
+    _insert_svc(db, verification=VERIFICATIONTYPES.MANUAL_TEST)
+    db.insert_annotation_impl(REQ_ID, AnnotationData(element_kind="METHOD", fully_qualified_name="com.example.Foo.bar"))
+    _insert_mvr_dated(db, MVR_ID_A, [SVC_ID], passed=False, date_iso="2026-01-01T00:00:00Z")
+    _insert_mvr_dated(db, MVR_ID_B, [SVC_ID], passed=True, date_iso="2026-01-02T00:00:00Z")
+    db.commit()
+
+    repo = RequirementsRepository(db)
+    stats = StatisticsService(repo)
+
+    manual = stats.requirement_statistics[REQ_ID].manual_tests
+    assert manual.total == 1
+    assert manual.passed == 1
+    assert manual.failed == 0
+    assert stats.requirement_statistics[REQ_ID].completed is True
+    assert stats.total_statistics.passed_manual_tests == 1
+    assert stats.total_statistics.failed_manual_tests == 0
+    assert stats.total_statistics.total_manual_tests == 1
+
+
+def test_supersession_pass_then_fail_counts_as_failed(db):
+    """Later fail supersedes earlier pass — requirement is not met."""
+    _insert_req(db)
+    _insert_svc(db, verification=VERIFICATIONTYPES.MANUAL_TEST)
+    db.insert_annotation_impl(REQ_ID, AnnotationData(element_kind="METHOD", fully_qualified_name="com.example.Foo.bar"))
+    _insert_mvr_dated(db, MVR_ID_A, [SVC_ID], passed=True, date_iso="2026-01-01T00:00:00Z")
+    _insert_mvr_dated(db, MVR_ID_B, [SVC_ID], passed=False, date_iso="2026-01-02T00:00:00Z")
+    db.commit()
+
+    repo = RequirementsRepository(db)
+    stats = StatisticsService(repo)
+
+    manual = stats.requirement_statistics[REQ_ID].manual_tests
+    assert manual.total == 1
+    assert manual.passed == 0
+    assert manual.failed == 1
+    assert stats.requirement_statistics[REQ_ID].completed is False
+
+
+def test_supersession_mixed_tz_offsets_latest_utc_wins(db):
+    """UTC 14:30 (+00:00) beats UTC 13:30 (+01:00) even though wall-clock strings differ."""
+    _insert_req(db)
+    _insert_svc(db, verification=VERIFICATIONTYPES.MANUAL_TEST)
+    db.insert_annotation_impl(REQ_ID, AnnotationData(element_kind="METHOD", fully_qualified_name="com.example.Foo.bar"))
+    _insert_mvr_dated(db, MVR_ID_A, [SVC_ID], passed=False, date_iso="2026-01-15T14:30:00+01:00")  # UTC 13:30
+    _insert_mvr_dated(db, MVR_ID_B, [SVC_ID], passed=True, date_iso="2026-01-15T14:30:00+00:00")  # UTC 14:30
+    db.commit()
+
+    repo = RequirementsRepository(db)
+    stats = StatisticsService(repo)
+
+    assert stats.requirement_statistics[REQ_ID].manual_tests.passed == 1
+    assert stats.requirement_statistics[REQ_ID].completed is True
 
 
 def test_empty_database(db):

--- a/tests/unit/reqstool/services/test_statistics_service.py
+++ b/tests/unit/reqstool/services/test_statistics_service.py
@@ -409,3 +409,60 @@ def test_total_stats_non_code_properties_all_zero():
     ts = TotalStats()
     assert ts.non_code_total == 0
     assert ts.non_code_completed == 0
+
+
+def test_supersession_three_mvrs_only_latest_counts(db):
+    """Three MVRs for one SVC — only the latest contributes to totals."""
+    MVR_ID_C = UrnId(urn=URN, id="MVR_C")
+    _insert_req(db)
+    _insert_svc(db, verification=VERIFICATIONTYPES.MANUAL_TEST)
+    db.insert_annotation_impl(REQ_ID, AnnotationData(element_kind="METHOD", fully_qualified_name="com.example.Foo.bar"))
+    _insert_mvr_dated(db, MVR_ID_A, [SVC_ID], passed=False, date_iso="2026-01-01T00:00:00Z")
+    _insert_mvr_dated(db, MVR_ID_B, [SVC_ID], passed=False, date_iso="2026-01-02T00:00:00Z")
+    _insert_mvr_dated(db, MVR_ID_C, [SVC_ID], passed=True, date_iso="2026-01-03T00:00:00Z")
+    db.commit()
+
+    repo = RequirementsRepository(db)
+    stats = StatisticsService(repo)
+
+    manual = stats.requirement_statistics[REQ_ID].manual_tests
+    assert manual.total == 1
+    assert manual.passed == 1
+    assert manual.failed == 0
+    assert stats.requirement_statistics[REQ_ID].completed is True
+    # Global totals count only the effective (latest) verdict
+    assert stats.total_statistics.total_manual_tests == 1
+    assert stats.total_statistics.passed_manual_tests == 1
+    assert stats.total_statistics.failed_manual_tests == 0
+
+
+def test_global_totals_reflect_only_effective_mvr_verdicts(db):
+    """total_manual_tests counts effective verdicts per SVC, not all MVR records."""
+    SVC_ID_2 = UrnId(urn=URN, id="SVC_002")
+    REQ_ID_2 = UrnId(urn=URN, id="REQ_002")
+    MVR_ID_C = UrnId(urn=URN, id="MVR_C")
+
+    # SVC_001: 2 MVRs — latest passes
+    _insert_req(db)
+    _insert_svc(db, verification=VERIFICATIONTYPES.MANUAL_TEST)
+    db.insert_annotation_impl(REQ_ID, AnnotationData(element_kind="METHOD", fully_qualified_name="com.example.Foo.bar"))
+    _insert_mvr_dated(db, MVR_ID_A, [SVC_ID], passed=False, date_iso="2026-01-01T00:00:00Z")
+    _insert_mvr_dated(db, MVR_ID_B, [SVC_ID], passed=True, date_iso="2026-01-02T00:00:00Z")
+
+    # SVC_002: 1 MVR — fails
+    _insert_req(db, req_id=REQ_ID_2)
+    _insert_svc(db, svc_id=SVC_ID_2, req_ids=[REQ_ID_2], verification=VERIFICATIONTYPES.MANUAL_TEST)
+    db.insert_annotation_impl(
+        REQ_ID_2, AnnotationData(element_kind="METHOD", fully_qualified_name="com.example.Foo.bar2")
+    )
+    _insert_mvr_dated(db, MVR_ID_C, [SVC_ID_2], passed=False, date_iso="2026-01-01T00:00:00Z")
+    db.commit()
+
+    repo = RequirementsRepository(db)
+    stats = StatisticsService(repo)
+
+    ts = stats.total_statistics
+    # 2 SVCs each with one effective verdict
+    assert ts.total_manual_tests == 2
+    assert ts.passed_manual_tests == 1
+    assert ts.failed_manual_tests == 1

--- a/tests/unit/reqstool/storage/test_requirements_repository.py
+++ b/tests/unit/reqstool/storage/test_requirements_repository.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 from reqstool.common.models.lifecycle import LIFECYCLESTATE
 from reqstool.common.models.urn_id import UrnId
@@ -416,3 +418,91 @@ def test_non_code_implementation_round_trip(db, impl_type):
     repo = RequirementsRepository(db)
     reqs = repo.get_all_requirements()
     assert reqs[req_id].implementation is impl_type
+
+
+# -- MVR supersession helpers --
+
+
+def _ts(iso: str) -> datetime:
+    return datetime.fromisoformat(iso)
+
+
+def _insert_mvr_dated(db, mvr_id, svc_ids, passed, date_iso: str | None):
+    date = _ts(date_iso) if date_iso else None
+    mvr = MVRData(id=mvr_id, passed=passed, svc_ids=svc_ids, date=date)
+    db.insert_mvr(mvr_id.urn, mvr)
+    return mvr
+
+
+MVR_ID_A = UrnId(urn=URN, id="MVR_A")
+MVR_ID_B = UrnId(urn=URN, id="MVR_B")
+MVR_ID_C = UrnId(urn=URN, id="MVR_C")
+
+
+def test_get_effective_mvr_single_no_date(db):
+    _insert_requirement(db)
+    _insert_svc(db, SVC_ID, req_ids=[REQ_ID])
+    _insert_mvr_dated(db, MVR_ID, [SVC_ID], passed=True, date_iso=None)
+    db.commit()
+
+    repo = RequirementsRepository(db)
+    eff = repo.get_effective_mvr_for_svc(SVC_ID)
+    assert eff is not None
+    assert eff.id == MVR_ID
+    assert repo.get_superseded_mvrs_for_svc(SVC_ID) == []
+
+
+def test_get_effective_mvr_latest_wins(db):
+    _insert_requirement(db)
+    _insert_svc(db, SVC_ID, req_ids=[REQ_ID])
+    _insert_mvr_dated(db, MVR_ID_A, [SVC_ID], passed=False, date_iso="2026-01-01T00:00:00Z")
+    _insert_mvr_dated(db, MVR_ID_B, [SVC_ID], passed=True, date_iso="2026-01-02T00:00:00Z")
+    db.commit()
+
+    repo = RequirementsRepository(db)
+    eff = repo.get_effective_mvr_for_svc(SVC_ID)
+    assert eff is not None
+    assert eff.id == MVR_ID_B
+    assert eff.passed is True
+
+    superseded = repo.get_superseded_mvrs_for_svc(SVC_ID)
+    assert len(superseded) == 1
+    assert superseded[0].id == MVR_ID_A
+
+
+def test_get_effective_mvr_mixed_tz_offsets(db):
+    _insert_requirement(db)
+    _insert_svc(db, SVC_ID, req_ids=[REQ_ID])
+    # UTC 13:30 via +01:00 offset (earlier)
+    _insert_mvr_dated(db, MVR_ID_A, [SVC_ID], passed=False, date_iso="2026-01-15T14:30:00+01:00")
+    # UTC 14:30 (later)
+    _insert_mvr_dated(db, MVR_ID_B, [SVC_ID], passed=True, date_iso="2026-01-15T14:30:00+00:00")
+    db.commit()
+
+    repo = RequirementsRepository(db)
+    eff = repo.get_effective_mvr_for_svc(SVC_ID)
+    assert eff is not None
+    assert eff.id == MVR_ID_B  # UTC 14:30 > UTC 13:30
+
+
+def test_get_effective_mvr_none_when_no_mvrs(db):
+    _insert_requirement(db)
+    _insert_svc(db, SVC_ID, req_ids=[REQ_ID])
+    db.commit()
+
+    repo = RequirementsRepository(db)
+    assert repo.get_effective_mvr_for_svc(SVC_ID) is None
+
+
+def test_mvr_date_round_trips_through_db(db):
+    _insert_requirement(db)
+    _insert_svc(db, SVC_ID, req_ids=[REQ_ID])
+    original = _ts("2026-03-15T09:00:00+01:00")
+    mvr = MVRData(id=MVR_ID, passed=True, svc_ids=[SVC_ID], date=original)
+    db.insert_mvr(MVR_ID.urn, mvr)
+    db.commit()
+
+    repo = RequirementsRepository(db)
+    loaded = repo.get_all_mvrs()[MVR_ID]
+    assert loaded.date is not None
+    assert loaded.date == original  # TZ-aware equality preserves semantics


### PR DESCRIPTION
## Summary

Fixes #72. When an SVC is manually verified more than once (fail → fix → pass), the requirement was incorrectly reported as not met because **all** MVRs were counted. The fix: the MVR with the **latest date is the verdict**; older ones are kept as audit history but excluded from the pass/fail computation.

- **Schema**: optional `date` field on mvrs.yml entries (`format: date-time`, timezone required, e.g. `"2026-01-15T14:30:00Z"`). Required by semantic validation when >1 MVR references the same SVC.
- **Domain model**: `MVRData.date: Optional[datetime]` — timezone-aware; stored as original ISO string in SQLite, ordered via SQLite's `datetime()` so mixed offsets sort correctly by UTC moment.
- **New repo helpers**: `get_effective_mvr_for_svc()` (ROW_NUMBER window query), `get_superseded_mvrs_for_svc()`, `get_effective_mvr_verdict_counts()` batch aggregation.
- **`StatisticsService`**: verdict built from one effective MVR per SVC via single aggregation query; eliminates N+1.
- **`details.py`**: `_compute_meets` uses effective MVR; `get_svc_details` / `get_mvr_details` add `date` and `superseded` fields (serialized as ISO string).
- **`SemanticValidator`**: new `_validate_mvr_supersession` — errors on missing `date` for multi-MVR SVCs and on exact UTC timestamp ties.
- **Report templates** (AsciiDoc + Markdown): show `date`; mark superseded MVRs as history.
- **Export** service + schema: include `date` field (correctly serialized as ISO string).
- **Index**: `idx_mvrs_date` on `mvrs(date)` to support `ORDER BY datetime(date)`.

## Example mvrs.yml with supersession

```yaml
results:
  - id: MVR_001
    svc_ids: ["SVC_021"]
    date: "2026-01-10T09:00:00Z"
    pass: false
    comment: "XSD validation failed — required fields missing."

  - id: MVR_002
    svc_ids: ["SVC_021"]
    date: "2026-01-15T14:30:00Z"
    pass: true
    comment: "All fields present. Validation passed."
```

Result: `T1 P1` (not `T2 P1 F1`). Requirement met.

## Test plan

- [x] 717 unit tests pass (`hatch run dev:pytest tests/unit`)
- [x] `black` + `flake8` clean
- [x] Regression smoke — `status` and `report` output identical to `main` for all three fixtures:
  - `tests/resources/test_data/data/local/test_standard/baseline/ms-001`
  - `tests/resources/test_data/data/local/test_basic/baseline/ms-101`
  - `../reqstool-demo/docs/reqstool` (pre-built `target/` used)
- [x] New supersession scenario tests — `test_supersession_fail_then_pass_counts_as_passed`, `test_supersession_pass_then_fail_counts_as_failed`, `test_supersession_mixed_tz_offsets_latest_utc_wins`
- [x] Repository helper tests — `test_get_effective_mvr_single_no_date`, `test_get_effective_mvr_latest_wins`, `test_get_effective_mvr_mixed_tz_offsets`, `test_get_effective_mvr_none_when_no_mvrs`, `test_mvr_date_round_trips_through_db`
- [x] Validator supersession tests — missing `date` error, exact-UTC-tie error, valid dated pair passes, single undated passes
- [x] `details.py` supersession tests — `_compute_meets` fail→pass and pass→fail scenarios, `get_svc_details` `superseded` flag, `get_mvr_details` `date` field
- [x] Export serialization tests — `date` is an ISO string (not raw `datetime`), `json.dumps` passes without custom encoder; undated MVR omits field
- [x] Global-totals correctness — 3-MVR scenario counts only latest; multi-SVC totals reflect effective verdicts only

## Notes for reviewer

All test plan items above were executed during development, not just written. Specific things verified:

**Regression smoke**: Captured `status` and `report --format asciidoc` output on `main`, then re-ran on this branch. Diffed all three fixtures — zero delta. This confirms no unintended output changes for existing MVR files (which have no `date` field and a single MVR per SVC).

**The core bug scenario** (issue #72 — `T2 P1 F1` → `T1 P1`): covered by `test_supersession_fail_then_pass_counts_as_passed` in `test_statistics_service.py` using direct DB insertion, and by `test_compute_meets_superseded_fail_latest_pass_is_true` in `test_details.py`.

**Mixed timezone offsets** (the tricky case): `test_supersession_mixed_tz_offsets_latest_utc_wins` and `test_get_effective_mvr_mixed_tz_offsets` both verify that `2026-01-15T14:30:00+01:00` (UTC 13:30) loses to `2026-01-15T14:30:00+00:00` (UTC 14:30) — confirmed via SQLite's `datetime()` normalization.

**JSON export safety**: `test_export_mvr_with_date_serializes_as_iso_string` calls `json.dumps(result)` on the full export dict to catch the TypeError that would occur if a raw `datetime` object slipped through (this was finding #1 from the PR review).