### PR TITLE
fix(ci): reference correct shared workflow for docs build

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - "docs/**"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: reqstool/.github/.github/workflows/common-build-docs.yml@main

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   build:
-    uses: reqstool/.github/.github/workflows/build-docs.yml@main
+    uses: reqstool/.github/.github/workflows/common-build-docs.yml@main


### PR DESCRIPTION
## Summary

- The `build-docs.yml` workflow was calling `reqstool/.github/.github/workflows/build-docs.yml@main`, but the shared workflow was renamed to `common-build-docs.yml`
- This caused every docs CI run to fail immediately with a workflow file not found error
- Fix: update the `uses:` reference to `common-build-docs.yml`

## Test plan

- [ ] Verify the `Build Docs` check passes on this PR