### PR TITLE
fix(ci): add explicit least-privilege permissions to all workflows

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - "docs/**"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: reqstool/.github/.github/workflows/build-docs.yml@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ on:
       - reopened
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   linting:
     name: Reuse linting job

--- a/.github/workflows/check-semantic-pr.yml
+++ b/.github/workflows/check-semantic-pr.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   check:
     uses: reqstool/.github/.github/workflows/check-semantic-pr.yml@main

--- a/.github/workflows/check_release.yml
+++ b/.github/workflows/check_release.yml
@@ -2,6 +2,8 @@ name: Check Release
 on:
   workflow_call:
 
+permissions: {}
+
 jobs:
   check-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   linting:
     runs-on: ubuntu-latest

--- a/.github/workflows/release_prod.yml
+++ b/.github/workflows/release_prod.yml
@@ -9,6 +9,9 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: "${{ github.repository_owner }}/reqstool"
 
+permissions:
+  contents: read
+
 jobs:
   check-release:
     name: Reuse check release

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -1,10 +1,13 @@
 name: Build and publish to Test PyPI
 
 on:
-  workflow_dispatch: 
+  workflow_dispatch:
   push:
     branches:
       - main
+
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Fixes all 9 open GitHub code scanning alerts for `actions/missing-workflow-permissions` (alerts #3, #4, #5, #6, #7, #8, #24, #25, #26).

Each workflow now declares the minimum `GITHUB_TOKEN` permissions required, following the principle of least privilege:

| Workflow | Permissions added |
|---|---|
| `build-docs.yml` | `contents: read` |
| `lint.yml` | `contents: read` |
| `check_release.yml` | `{}` (empty — only uses GitHub context vars, no repo access) |
| `check-semantic-pr.yml` | `contents: read`, `pull-requests: read` |
| `build.yml` | `contents: read` |
| `release_prod.yml` | `contents: read` at workflow level (existing job-level overrides for `publish-to-pypi` and `publish-image-to-ghcr` are unchanged) |
| `release_test.yml` | `contents: read` at workflow level (existing `id-token: write` on publish job unchanged) |

## Test plan

- [ ] Verify build workflow passes on this PR
- [ ] Confirm code scanning alerts are resolved after merge