### PR TITLE
docs(contributing): document reqstool/openspec CLI prerequisites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,10 @@ For DCO sign-off, commit conventions, and code review process, see the organizat
 
 - Python 3.10+
 - [Hatch](https://hatch.pypa.io/) (`pip install hatch`)
+- [reqstool](https://github.com/reqstool/reqstool-client) (`pipx install reqstool`) — for dogfooding
+  this repo's own traceability data against the latest PyPI release; use `hatch run dev:...` below
+  to exercise your local changes instead
+- [OpenSpec](https://github.com/Fission-AI/OpenSpec) (`npm install -g @fission-ai/openspec`)
 
 ## Setup
 
@@ -17,9 +21,13 @@ cd reqstool-client
 hatch env create dev
 ```
 
-If using Claude Code, regenerate the `opsx` slash commands and OpenSpec skills
-(`.claude/commands/opsx/`, `.claude/skills/openspec-*`) after cloning — they're
-CLI-generated tool scaffolding, not committed to the repo:
+If using Claude Code, opening this repo will prompt you to confirm adding the `reqstool-ai`
+marketplace and enabling the `reqstool`/`reqstool-openspec` plugins (configured in
+`.claude/settings.json`) — accept the prompt.
+
+Then regenerate the `opsx` slash commands and OpenSpec skills
+(`.claude/commands/opsx/`, `.claude/skills/openspec-*`) — they're CLI-generated tool scaffolding,
+not committed to the repo:
 
 ```bash
 openspec update   # or: openspec init --tools claude --force


### PR DESCRIPTION
## Summary
- Neither the `reqstool` CLI nor the `openspec` CLI was documented as a prerequisite anywhere, despite both being needed to dogfood this repo's own traceability data (`reqstool status`/`validate`) and to regenerate the `opsx`/OpenSpec Claude Code scaffolding (`openspec update`).
- Adds `pipx install reqstool` and `npm install -g @fission-ai/openspec` to `Prerequisites`.
- Notes the Claude Code marketplace/plugin install prompt contributors will see on first open, now that `.claude/settings.json` enables `reqstool@reqstool-ai`/`reqstool-openspec@reqstool-ai` by default (#415/#416).

## Test plan
- [x] `git diff CONTRIBUTING.md` reviewed — only the Prerequisites/Setup sections changed