### PR TITLE
fix(schema): add ANNOTATION_TYPE to annotations elementKind enum

### DIFF
--- a/src/reqstool/models/generated/annotations_schema.py
+++ b/src/reqstool/models/generated/annotations_schema.py
@@ -10,12 +10,13 @@ from pydantic import BaseModel, ConfigDict, RootModel, constr
 
 class ElementKind(Enum):
     """
-    Enum for all valid elementKinds. E.g. CLASS, ENUM, INTERFACE, RECORD, METHOD, FIELD
+    Enum for all valid elementKinds. E.g. CLASS, ENUM, INTERFACE, ANNOTATION_TYPE, RECORD, METHOD, FIELD
     """
 
     CLASS = 'CLASS'
     ENUM = 'ENUM'
     INTERFACE = 'INTERFACE'
+    ANNOTATION_TYPE = 'ANNOTATION_TYPE'
     RECORD = 'RECORD'
     METHOD = 'METHOD'
     FIELD = 'FIELD'
@@ -24,7 +25,7 @@ class ElementKind(Enum):
 class Requirement(BaseModel):
     elementKind: ElementKind
     """
-    Enum for all valid elementKinds. E.g. CLASS, ENUM, INTERFACE, RECORD, METHOD, FIELD
+    Enum for all valid elementKinds. E.g. CLASS, ENUM, INTERFACE, ANNOTATION_TYPE, RECORD, METHOD, FIELD
     """
     fullyQualifiedName: str
     """

--- a/src/reqstool/resources/schemas/v1/annotations.schema.json
+++ b/src/reqstool/resources/schemas/v1/annotations.schema.json
@@ -51,11 +51,12 @@
                         "CLASS",
                         "ENUM",
                         "INTERFACE",
+                        "ANNOTATION_TYPE",
                         "RECORD",
                         "METHOD",
                         "FIELD"
                     ],
-                    "description": "Enum for all valid elementKinds. E.g. CLASS, ENUM, INTERFACE, RECORD, METHOD, FIELD"
+                    "description": "Enum for all valid elementKinds. E.g. CLASS, ENUM, INTERFACE, ANNOTATION_TYPE, RECORD, METHOD, FIELD"
                 },
                 "fullyQualifiedName": {
                     "type": "string",


### PR DESCRIPTION
## Summary
Fixes #418 — `annotations.schema.json`'s `elementKind` enum was missing `ANNOTATION_TYPE`, the `javax.lang.model.element.ElementKind` value Java reports for `@interface` declarations. `@Requirements`/`@SVCs` both target `TYPE` among other element kinds, so annotating an annotation type declaration (including self-applying the annotation to its own declaration) is legal Java but was rejected by the schema.

Found while dogfooding `reqstool-java-annotations` (self-applying its own `@Requirements` to the `Requirements`/`SVCs` declarations themselves) — part of the org-wide OpenSpec/reqstool dogfooding rollout.

- Adds `ANNOTATION_TYPE` to the enum in `src/reqstool/resources/schemas/v1/annotations.schema.json`
- Regenerates `src/reqstool/models/generated/annotations_schema.py` via `hatch run dev:codegen`

## Test plan
- [x] `hatch run dev:pytest --cov=reqstool` — 938 passed, 2 skipped (unrelated, missing GITHUB_TOKEN/GITLAB_TOKEN)
- [x] Verified locally against `reqstool-java-annotations`'s self-applied dataset: `reqstool status local -p docs/reqstool` no longer raises the schema error