### PR TITLE
fix(schema): allow ANNOTATION_TYPE in storage CHECK constraints

### DIFF
--- a/src/reqstool/models/annotations.py
+++ b/src/reqstool/models/annotations.py
@@ -10,7 +10,7 @@ from reqstool.common.models.urn_id import UrnId
 class AnnotationData(BaseModel):
     model_config = ConfigDict(frozen=True)
 
-    element_kind: str  # FIELD, METHOD, CLASS, ENUM, INTERFACE, RECORD
+    element_kind: str  # FIELD, METHOD, CLASS, ENUM, INTERFACE, ANNOTATION_TYPE, RECORD
     fully_qualified_name: str
 
 

--- a/src/reqstool/resources/schemas/v1/export_output.schema.json
+++ b/src/reqstool/resources/schemas/v1/export_output.schema.json
@@ -338,7 +338,7 @@
             "properties": {
                 "element_kind": {
                     "type": "string",
-                    "enum": ["FIELD", "METHOD", "CLASS", "ENUM", "INTERFACE", "RECORD"],
+                    "enum": ["FIELD", "METHOD", "CLASS", "ENUM", "INTERFACE", "ANNOTATION_TYPE", "RECORD"],
                     "description": "Kind of code element annotated"
                 },
                 "fully_qualified_name": {

--- a/src/reqstool/storage/schema.py
+++ b/src/reqstool/storage/schema.py
@@ -97,7 +97,7 @@ CREATE TABLE IF NOT EXISTS annotations_impls (
     req_urn TEXT NOT NULL,
     req_id TEXT NOT NULL,
     element_kind TEXT NOT NULL CHECK (element_kind IN (
-        'FIELD', 'METHOD', 'CLASS', 'ENUM', 'INTERFACE', 'RECORD'
+        'FIELD', 'METHOD', 'CLASS', 'ENUM', 'INTERFACE', 'ANNOTATION_TYPE', 'RECORD'
     )),
     fqn TEXT NOT NULL,
     PRIMARY KEY (req_urn, req_id, element_kind, fqn),
@@ -108,7 +108,7 @@ CREATE TABLE IF NOT EXISTS annotations_tests (
     svc_urn TEXT NOT NULL,
     svc_id TEXT NOT NULL,
     element_kind TEXT NOT NULL CHECK (element_kind IN (
-        'FIELD', 'METHOD', 'CLASS', 'ENUM', 'INTERFACE', 'RECORD'
+        'FIELD', 'METHOD', 'CLASS', 'ENUM', 'INTERFACE', 'ANNOTATION_TYPE', 'RECORD'
     )),
     fqn TEXT NOT NULL,
     PRIMARY KEY (svc_urn, svc_id, element_kind, fqn),


### PR DESCRIPTION
## Summary
Follow-up to #419, which fixed `annotations.schema.json`'s `elementKind` enum but missed two other independent copies of the same enum:

- `storage/schema.py`'s `annotations_impls`/`annotations_tests` `CHECK` constraints — these **silently dropped the row** via `INSERT OR IGNORE` with no warning logged, so a requirement/SVC with an `ANNOTATION_TYPE` annotation location passed schema validation but then vanished from the database with no error at all.
- `export_output.schema.json`'s own `element_kind` enum copy (used by the `export` command's output validation, tested by `test_output_schemas.py`).

Found by re-running [reqstool-java-annotations#166](https://github.com/reqstool/reqstool-java-annotations/pull/166)'s CI after merging #419: the schema validation error was gone, but `ANNOTATIONS_001` (the requirement self-applied to the `Requirements`/`SVCs` annotation declarations themselves) still showed "not implemented" with no error — confirming the `CHECK` constraint gap was silently swallowing the insert.

## Test plan
- [x] `hatch run dev:pytest --cov=reqstool` — 938 passed, 2 skipped (unrelated)
- [x] Reinstalled editable (`pipx install --force -e .`) against `reqstool-java-annotations`'s real self-applied dataset: full two-pass self-apply build → `reqstool status` → **3/3 requirements complete, PASS** (previously 2/3, `ANNOTATIONS_001` silently missing)